### PR TITLE
Use central PROJECT_ROOT in scripts

### DIFF
--- a/scripts/extractimages.py
+++ b/scripts/extractimages.py
@@ -22,7 +22,7 @@ except AttributeError:
 
 IMG_DIR = main.PROJECT_ROOT / "img"
 
-progress_file = Path(__file__).resolve().parent / "progress.txt"
+progress_file = main.PROJECT_ROOT / "progress.txt"
 
 def write_progress(updates: Optional[Dict[int, str]] = None):
     try:

--- a/scripts/nye_emnekoder.py
+++ b/scripts/nye_emnekoder.py
@@ -1,6 +1,7 @@
 import json
 import os
 from collections import defaultdict
+import main
 
 def splitt_emnekode(kode):
     """Deler opp i bokstavprefiks og tall"""
@@ -19,7 +20,7 @@ def felles_prefiks(prefikser):
     return resultat
 
 def main():
-    file_path = os.path.join(os.path.dirname(__file__), "ntnu_emner.json")
+    file_path = main.PROJECT_ROOT / "ntnu_emner.json"
     with open(file_path, encoding='utf-8') as f:
         emner = json.load(f)
 
@@ -54,7 +55,7 @@ def main():
 
     print("\nFullført.")
 
-    output_path = os.path.join(os.path.dirname(__file__), "ntnu_emner_sammenslaatt.json")
+    output_path = main.PROJECT_ROOT / "ntnu_emner_sammenslaatt.json"
     with open(output_path, 'w', encoding='utf-8') as f:
         json.dump(resultat, f, indent=2, ensure_ascii=False)
 

--- a/scripts/objecttojson.py
+++ b/scripts/objecttojson.py
@@ -1,6 +1,7 @@
 import os
 import json
 from dataclasses import asdict
+import main
 
 def main(tasks):
     """
@@ -8,7 +9,7 @@ def main(tasks):
     Dersom en oppgave med samme exam_version, task_number og subject finnes,
     byttes den ut med den nye prosesseringen av oppgaven.
     """
-    file_path = os.path.join(os.path.dirname(__file__), 'tasks.json')
+    file_path = main.PROJECT_ROOT / 'tasks.json'
 
     # Last inn eksisterende oppgaver dersom fila finnes
     if os.path.exists(file_path):

--- a/scripts/ocrpdf.py
+++ b/scripts/ocrpdf.py
@@ -5,6 +5,7 @@ from google.cloud import vision
 from pathlib import Path
 from tqdm import tqdm
 import sys
+import main
 
 # Sørg for UTF-8 utskrift i terminalen
 sys.stdout.reconfigure(encoding='utf-8')
@@ -19,7 +20,7 @@ os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = json_path
 print(f"\n[GOOGLE] Successfully connected to Google Vision API using:\n{json_path}\n")
 
 # Definer sti for progress.txt
-progress_file = Path(__file__).resolve().parent / "progress.txt"
+progress_file = main.PROJECT_ROOT / "progress.txt"
 
 # Tømmer hele progress.txt ved oppstart
 with open(progress_file, "w", encoding="utf-8") as f:
@@ -119,7 +120,7 @@ async def process_image(index, image, ocr_progress):
 
 async def main_async():
     # Les PDF-sti fra dir.txt
-    script_dir = Path(__file__).resolve().parent
+    script_dir = main.PROJECT_ROOT
     dir_txt = script_dir / "dir.txt"
 
     if not dir_txt.exists():

--- a/scripts/prompttotext.py
+++ b/scripts/prompttotext.py
@@ -5,9 +5,10 @@ import contextvars
 from openai import OpenAI  # Using OpenAI SDK for DeepSeek
 import builtins
 from pathlib import Path
+import main
 
 # Definer sti for progress.txt
-progress_file = Path(__file__).resolve().parent / "progress.txt"
+progress_file = main.PROJECT_ROOT / "progress.txt"
 
 def update_progress_line3(value="1"):
     """

--- a/scripts/purge_temaer.py
+++ b/scripts/purge_temaer.py
@@ -4,10 +4,10 @@ Script to purge all "Temaer" lists in ntnu_emner.json by setting each to an empt
 """
 import json
 import sys
-from pathlib import Path
+import main
 
 # Path to the JSON file
-JSON_PATH = Path(__file__).resolve().parent / "ntnu_emner.json"
+JSON_PATH = main.PROJECT_ROOT / "ntnu_emner.json"
 
 
 def purge_temaer():

--- a/scripts/taskprocessing.py
+++ b/scripts/taskprocessing.py
@@ -1,5 +1,6 @@
 import prompttotext
 import extractimages
+import main
 
 import asyncio
 import json
@@ -17,7 +18,7 @@ import json
 sys.stdout.reconfigure(encoding='utf-8')
 
 # Paths and global state
-db_dir = Path(__file__).resolve().parent
+db_dir = main.PROJECT_ROOT
 progress_file = db_dir / "progress.txt"
 JSON_PATH = db_dir / "ntnu_emner_sammenslaatt.json"
 IMG_PATH = db_dir / "img"
@@ -106,7 +107,7 @@ def get_topics(emnekode: str) -> str:
     Return comma-separated unique 'Temaer' for matching emnekoder,
     or default list if fewer than 6 topics are found.
     """
-    json_path = Path(__file__).resolve().parent / "ntnu_emner.json"
+    json_path = main.PROJECT_ROOT / "ntnu_emner.json"
 
     with json_path.open('r', encoding='utf-8') as f:
         data = json.load(f)


### PR DESCRIPTION
## Summary
- import `main` across scripts
- derive progress and data file paths from `main.PROJECT_ROOT`

## Testing
- `python3 -m py_compile $(git ls-files "scripts/*.py")`

------
https://chatgpt.com/codex/tasks/task_e_684412da519883269a9a685776abe470