### PR TITLE
Remove duplicate json import

### DIFF
--- a/scripts/taskprocessing.py
+++ b/scripts/taskprocessing.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass, field
 from typing import Optional, List, Dict
 from copy import deepcopy
 from collections import defaultdict
-import json
 
 # Ensure UTF-8 output
 sys.stdout.reconfigure(encoding='utf-8')


### PR DESCRIPTION
## Summary
- dedupe redundant `json` import

## Testing
- `python3 -m py_compile scripts/taskprocessing.py`


------
https://chatgpt.com/codex/tasks/task_e_6844157bf454832687a2f0df4a300fce