### PR TITLE
Refactor script paths

### DIFF
--- a/scripts/extractimages.py
+++ b/scripts/extractimages.py
@@ -1,7 +1,7 @@
 import taskprocessing
 import ocrpdf
 import prompttotext
-import main
+from project_paths import PROJECT_ROOT, IMG_DIR
 
 import os
 import shutil
@@ -20,9 +20,7 @@ try:
 except AttributeError:
     pass
 
-IMG_DIR = main.PROJECT_ROOT / "img"
-
-progress_file = main.PROJECT_ROOT / "progress.txt"
+progress_file = PROJECT_ROOT / "progress.txt"
 
 def write_progress(updates: Optional[Dict[int, str]] = None):
     try:

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -2,25 +2,29 @@ import ocrpdf
 import textnormalization
 import taskprocessing
 import objecttojson
-from pathlib import Path
 
-PROJECT_ROOT = Path(__file__).resolve().parent
-IMG_DIR = PROJECT_ROOT / "img"
+from project_paths import PROJECT_ROOT, IMG_DIR
 
 
-# Step 1: Run OCR PDF to get raw text
-rawtext = ocrpdf.main()
+def main():
+    """Run the full OCR and task processing workflow."""
+    # Step 1: Run OCR PDF to get raw text
+    rawtext = ocrpdf.main()
 
-# Step 2: Normalize text
-rawtext = textnormalization.normalize_text(rawtext)
+    # Step 2: Normalize text
+    rawtext = textnormalization.normalize_text(rawtext)
 
-# Step 4: Process tasks using taskseparation
-tasks = taskprocessing.main(rawtext)
+    # Step 4: Process tasks using taskseparation
+    tasks = taskprocessing.main(rawtext)
 
-# Step 5: Write the objects to the json file
-objecttojson.main(tasks)
+    # Step 5: Write the objects to the json file
+    objecttojson.main(tasks)
 
-# Step 5: Write the tasks to an output file
-# with open('output.txt', 'w', encoding='utf-8') as f:
-#     for task in tasks:
-#         f.write(task + '\n\n')
+    # Step 5: Write the tasks to an output file
+    # with open('output.txt', 'w', encoding='utf-8') as f:
+    #     for task in tasks:
+    #         f.write(task + '\n\n')
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/nye_emnekoder.py
+++ b/scripts/nye_emnekoder.py
@@ -1,7 +1,7 @@
 import json
 import os
 from collections import defaultdict
-import main
+from project_paths import PROJECT_ROOT
 
 def splitt_emnekode(kode):
     """Deler opp i bokstavprefiks og tall"""
@@ -20,7 +20,7 @@ def felles_prefiks(prefikser):
     return resultat
 
 def main():
-    file_path = main.PROJECT_ROOT / "ntnu_emner.json"
+    file_path = PROJECT_ROOT / "ntnu_emner.json"
     with open(file_path, encoding='utf-8') as f:
         emner = json.load(f)
 
@@ -55,7 +55,7 @@ def main():
 
     print("\nFullført.")
 
-    output_path = main.PROJECT_ROOT / "ntnu_emner_sammenslaatt.json"
+    output_path = PROJECT_ROOT / "ntnu_emner_sammenslaatt.json"
     with open(output_path, 'w', encoding='utf-8') as f:
         json.dump(resultat, f, indent=2, ensure_ascii=False)
 

--- a/scripts/objecttojson.py
+++ b/scripts/objecttojson.py
@@ -1,7 +1,7 @@
 import os
 import json
 from dataclasses import asdict
-import main
+from project_paths import PROJECT_ROOT
 
 def main(tasks):
     """
@@ -9,7 +9,7 @@ def main(tasks):
     Dersom en oppgave med samme exam_version, task_number og subject finnes,
     byttes den ut med den nye prosesseringen av oppgaven.
     """
-    file_path = main.PROJECT_ROOT / 'tasks.json'
+    file_path = PROJECT_ROOT / 'tasks.json'
 
     # Last inn eksisterende oppgaver dersom fila finnes
     if os.path.exists(file_path):

--- a/scripts/ocrpdf.py
+++ b/scripts/ocrpdf.py
@@ -2,10 +2,9 @@ import os
 import fitz  # For PDF-håndtering
 import asyncio
 from google.cloud import vision
-from pathlib import Path
 from tqdm import tqdm
 import sys
-import main
+from project_paths import PROJECT_ROOT
 
 # Sørg for UTF-8 utskrift i terminalen
 sys.stdout.reconfigure(encoding='utf-8')
@@ -20,7 +19,7 @@ os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = json_path
 print(f"\n[GOOGLE] Successfully connected to Google Vision API using:\n{json_path}\n")
 
 # Definer sti for progress.txt
-progress_file = main.PROJECT_ROOT / "progress.txt"
+progress_file = PROJECT_ROOT / "progress.txt"
 
 # Tømmer hele progress.txt ved oppstart
 with open(progress_file, "w", encoding="utf-8") as f:
@@ -120,7 +119,7 @@ async def process_image(index, image, ocr_progress):
 
 async def main_async():
     # Les PDF-sti fra dir.txt
-    script_dir = main.PROJECT_ROOT
+    script_dir = PROJECT_ROOT
     dir_txt = script_dir / "dir.txt"
 
     if not dir_txt.exists():

--- a/scripts/project_paths.py
+++ b/scripts/project_paths.py
@@ -1,0 +1,4 @@
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+IMG_DIR = PROJECT_ROOT / "img"

--- a/scripts/prompttotext.py
+++ b/scripts/prompttotext.py
@@ -4,11 +4,10 @@ import asyncio
 import contextvars
 from openai import OpenAI  # Using OpenAI SDK for DeepSeek
 import builtins
-from pathlib import Path
-import main
+from project_paths import PROJECT_ROOT
 
 # Definer sti for progress.txt
-progress_file = main.PROJECT_ROOT / "progress.txt"
+progress_file = PROJECT_ROOT / "progress.txt"
 
 def update_progress_line3(value="1"):
     """

--- a/scripts/purge_temaer.py
+++ b/scripts/purge_temaer.py
@@ -4,10 +4,10 @@ Script to purge all "Temaer" lists in ntnu_emner.json by setting each to an empt
 """
 import json
 import sys
-import main
+from project_paths import PROJECT_ROOT
 
 # Path to the JSON file
-JSON_PATH = main.PROJECT_ROOT / "ntnu_emner.json"
+JSON_PATH = PROJECT_ROOT / "ntnu_emner.json"
 
 
 def purge_temaer():

--- a/scripts/taskprocessing.py
+++ b/scripts/taskprocessing.py
@@ -1,6 +1,6 @@
 import prompttotext
 import extractimages
-import main
+from project_paths import PROJECT_ROOT, IMG_DIR
 
 import asyncio
 import json
@@ -18,10 +18,10 @@ import json
 sys.stdout.reconfigure(encoding='utf-8')
 
 # Paths and global state
-db_dir = main.PROJECT_ROOT
+db_dir = PROJECT_ROOT
 progress_file = db_dir / "progress.txt"
 JSON_PATH = db_dir / "ntnu_emner_sammenslaatt.json"
-IMG_PATH = db_dir / "img"
+IMG_PATH = IMG_DIR
 task_status = defaultdict(lambda: 0)
 
 # Prompt prefix
@@ -107,7 +107,7 @@ def get_topics(emnekode: str) -> str:
     Return comma-separated unique 'Temaer' for matching emnekoder,
     or default list if fewer than 6 topics are found.
     """
-    json_path = main.PROJECT_ROOT / "ntnu_emner.json"
+    json_path = PROJECT_ROOT / "ntnu_emner.json"
 
     with json_path.open('r', encoding='utf-8') as f:
         data = json.load(f)


### PR DESCRIPTION
## Summary
- centralize project paths in `project_paths` module
- update scripts to use `project_paths`
- wrap main workflow in `main()` function

## Testing
- `python3 -m py_compile $(git ls-files "scripts/*.py")`

------
https://chatgpt.com/codex/tasks/task_e_6844157aea8083268c821b71935a8229