### PR TITLE
Centralize and rename project config

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Python-delen startes med
 python -m scripts.main
 ```
 
-Du kan også bruke `python scripts/main.py`. Før kjøring må miljøvariabler som `OCRACLE_JSON_PATH` og `DEEPSEEK_API_KEY` settes. Alle skriptene bruker `project_paths.PROJECT_ROOT` for å finne filer.
+Du kan også bruke `python scripts/main.py`. Før kjøring må miljøvariabler som `OCRACLE_JSON_PATH` og `DEEPSEEK_API_KEY` settes. Alle skriptene henter innstillinger fra `project_config.py` hvor blant annet `PROJECT_ROOT`, `PROGRESS_FILE` og `PROMPT_CONFIG` er definert.
 
 
 ## Eksempel av prompting i taskprocessing.py:

--- a/scripts/extractimages.py
+++ b/scripts/extractimages.py
@@ -13,18 +13,17 @@ import json
 import sys
 from typing import List, Tuple, Dict, Optional
 from pathlib import Path
+from project_config import *
 
 try:
     sys.stdout.reconfigure(encoding="utf-8")
 except AttributeError:
     pass
 
-progress_file = PROJECT_ROOT / "progress.txt"
-
 def write_progress(updates: Optional[Dict[int, str]] = None):
     try:
-        if progress_file.exists():
-            with open(progress_file, "r", encoding="utf-8") as f:
+        if PROGRESS_FILE.exists():
+            with open(PROGRESS_FILE, "r", encoding="utf-8") as f:
                 lines = f.readlines()
         else:
             lines = []
@@ -39,20 +38,15 @@ def write_progress(updates: Optional[Dict[int, str]] = None):
         for idx, text in updates.items():
             lines[idx] = f"{text}\n"
 
-        with open(progress_file, "w", encoding="utf-8") as f:
+        with open(PROGRESS_FILE, "w", encoding="utf-8") as f:
             f.writelines(lines)
 
         for idx, text in updates.items():
-            print(f"[STATUS] | Wrote '{text}' to line {idx + 1} in {progress_file}")
+            print(f"[STATUS] | Wrote '{text}' to line {idx + 1} in {PROGRESS_FILE}")
     except Exception as e:
         print(f"[ERROR] Could not update progress file: {e}")
 
-_nonchalant = (
-    "DO AS YOU ARE TOLD AND RESPOND ONLY WITH WHAT IS ASKED FROM YOU. "
-    "DO NOT EXPLAIN OR SAY WHAT YOU ARE DOING. "
-    "DO NOT WRITE ANY SYMBOLS LIKE - OR \n OR CHANGE LETTER FORMATTING WITH ** AND SIMILAR. "
-    "YOU ARE USED IN A TEXT PROCESSING PYTHON PROGRAM SO THE TEXT SHOULD BE PLAIN. "
-)
+
 
 TEXT_LEN_LIMIT = 75
 MIN_CONTOUR_AREA = 15_000
@@ -158,7 +152,7 @@ async def extract_images(
             return {}
 
         prompt = (
-            _nonchalant + 
+            PROMPT_CONFIG + 
             f"Hvilke oppgave(r) fra denne listen {total_tasks} er på side {page_index} i teksten? "
             "Skriv oppgavene funnet på den siden separert med et komma. "
             "Eksempler på svar (uten anførselstegn): \"1\", \"2, 3\", \"1, 2, 3\", osv. "
@@ -209,7 +203,7 @@ async def extract_images(
 
             _, crop_buf = cv2.imencode(".png", crop)
             img_text = ocrpdf.detect_text(crop_buf.tobytes())
-            verify_prompt = (_nonchalant + "Does this text include put-together sentences? Respond 0 if yes, 1 if no. Text: " + img_text)
+            verify_prompt = (PROMPT_CONFIG + "Does this text include put-together sentences? Respond 0 if yes, 1 if no. Text: " + img_text)
             v_raw = await prompttotext.async_prompt_to_text(
                 verify_prompt, max_tokens=50, isNum=True, maxLen=2
             )

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -2,7 +2,7 @@ import ocrpdf
 import textnormalization
 import taskprocessing
 import objecttojson
-from project_paths import PROJECT_ROOT, IMG_DIR
+from project_config import *
 
 def main():
     """Run the full OCR and task processing workflow."""

--- a/scripts/nye_emnekoder.py
+++ b/scripts/nye_emnekoder.py
@@ -1,7 +1,7 @@
 import json
 import os
 from collections import defaultdict
-from project_paths import PROJECT_ROOT
+from project_config import *
 
 def splitt_emnekode(kode):
     """Deler opp i bokstavprefiks og tall"""
@@ -20,7 +20,7 @@ def felles_prefiks(prefikser):
     return resultat
 
 def main():
-    file_path = PROJECT_ROOT / "ntnu_emner.json"
+    file_path = EXAM_CODES_JSON
     with open(file_path, encoding='utf-8') as f:
         emner = json.load(f)
 
@@ -55,7 +55,7 @@ def main():
 
     print("\nFullført.")
 
-    output_path = PROJECT_ROOT / "ntnu_emner_sammenslaatt.json"
+    output_path = EXAM_CODES_MERGED_JSON
     with open(output_path, 'w', encoding='utf-8') as f:
         json.dump(resultat, f, indent=2, ensure_ascii=False)
 

--- a/scripts/objecttojson.py
+++ b/scripts/objecttojson.py
@@ -1,7 +1,7 @@
 import os
 import json
 from dataclasses import asdict
-from project_paths import PROJECT_ROOT
+from project_config import *
 
 def main(tasks):
     """
@@ -9,7 +9,7 @@ def main(tasks):
     Dersom en oppgave med samme exam_version, task_number og subject finnes,
     byttes den ut med den nye prosesseringen av oppgaven.
     """
-    file_path = PROJECT_ROOT / 'tasks.json'
+    file_path = TASKS_JSON
 
     # Last inn eksisterende oppgaver dersom fila finnes
     if os.path.exists(file_path):

--- a/scripts/ocrpdf.py
+++ b/scripts/ocrpdf.py
@@ -4,7 +4,7 @@ import asyncio
 from google.cloud import vision
 from tqdm import tqdm
 import sys
-from project_paths import PROJECT_ROOT
+from project_config import *
 
 # Sørg for UTF-8 utskrift i terminalen
 sys.stdout.reconfigure(encoding='utf-8')
@@ -18,11 +18,8 @@ if not json_path or not os.path.exists(json_path):
 os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = json_path
 print(f"\n[GOOGLE] Successfully connected to Google Vision API using:\n{json_path}\n")
 
-# Definer sti for progress.txt
-progress_file = PROJECT_ROOT / "progress.txt"
-
-# Tømmer hele progress.txt ved oppstart
-with open(progress_file, "w", encoding="utf-8") as f:
+# Definer sti for progress.txt and empty file at startup
+with open(PROGRESS_FILE, "w", encoding="utf-8") as f:
     f.write("")
 
 def update_progress_line1(value="1"):
@@ -31,19 +28,19 @@ def update_progress_line1(value="1"):
     (Her brukes linje 1 til å vise Google Vision API-status.)
     """
     try:
-        if progress_file.exists():
-            with open(progress_file, "r", encoding="utf-8") as f:
+        if PROGRESS_FILE.exists():
+            with open(PROGRESS_FILE, "r", encoding="utf-8") as f:
                 lines = f.readlines()
         else:
             lines = []
         if len(lines) < 1:
             lines = ["\n"]
         lines[0] = f"{value}\n"
-        with open(progress_file, "w", encoding="utf-8") as f:
+        with open(PROGRESS_FILE, "w", encoding="utf-8") as f:
             f.writelines(lines)
-        print(f"[STATUS] | Updated line 1 of {progress_file} with '{value}'")
+        print(f"[STATUS] | Updated line 1 of {PROGRESS_FILE} with '{value}'")
     except Exception as e:
-        print(f"[ERROR] Could not update line 1 in {progress_file}: {e}")
+        print(f"[ERROR] Could not update line 1 in {PROGRESS_FILE}: {e}")
 
 def update_progress_line2(value):
     """
@@ -51,19 +48,19 @@ def update_progress_line2(value):
     (Her skrives en tallrekke som indikerer hvor mange sider som er prosessert.)
     """
     try:
-        if progress_file.exists():
-            with open(progress_file, "r", encoding="utf-8") as f:
+        if PROGRESS_FILE.exists():
+            with open(PROGRESS_FILE, "r", encoding="utf-8") as f:
                 lines = f.readlines()
         else:
             lines = []
         if len(lines) < 2:
             lines += ["\n"] * (2 - len(lines))
         lines[1] = f"{value}\n"
-        with open(progress_file, "w", encoding="utf-8") as f:
+        with open(PROGRESS_FILE, "w", encoding="utf-8") as f:
             f.writelines(lines)
-        print(f"[STATUS] | Updated line 2 of {progress_file} with '{value}'")
+        print(f"[STATUS] | Updated line 2 of {PROGRESS_FILE} with '{value}'")
     except Exception as e:
-        print(f"[ERROR] Could not update line 2 in {progress_file}: {e}")
+        print(f"[ERROR] Could not update line 2 in {PROGRESS_FILE}: {e}")
 
 # Sett opp Google Vision API-status (linje 1)
 update_progress_line1("1")
@@ -119,8 +116,7 @@ async def process_image(index, image, ocr_progress):
 
 async def main_async():
     # Les PDF-sti fra dir.txt
-    script_dir = PROJECT_ROOT
-    dir_txt = script_dir / "dir.txt"
+    dir_txt = DIR_FILE
 
     if not dir_txt.exists():
         print(f"[ERROR] Could not find dir.txt at {dir_txt}")

--- a/scripts/project_config.py
+++ b/scripts/project_config.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+"""Centralized configuration constants used throughout the project."""
+
+# Base directory containing all Python scripts and related assets
+PROJECT_ROOT = Path(__file__).resolve().parent
+
+# File locations
+PROGRESS_FILE = PROJECT_ROOT / "progress.txt"
+DIR_FILE = PROJECT_ROOT / "dir.txt"
+SUBJECT_FILE = PROJECT_ROOT / "subject.txt"
+TASKS_JSON = PROJECT_ROOT / "tasks.json"
+
+# JSON databases for subject information
+EXAM_CODES_JSON = PROJECT_ROOT / "ntnu_emner.json"
+EXAM_CODES_MERGED_JSON = PROJECT_ROOT / "ntnu_emner_sammenslaatt.json"
+
+# Directory locations
+IMG_DIR = PROJECT_ROOT / "img"
+
+# Optional directory for stored PDF files (one level above scripts)
+PDF_DIR = PROJECT_ROOT.parent / "pdf"
+
+# Prefix for all language model prompts to keep responses short and direct
+PROMPT_CONFIG = (
+    "DO AS YOU ARE TOLD AND RESPOND ONLY WITH WHAT IS ASKED FROM YOU. "
+    "DO NOT EXPLAIN OR SAY WHAT YOU ARE DOING (e.g. here is the..., below is..., sure here is..., etc.). "
+    "DO NOT WRITE ANY SYMBOLS LIKE - OR \n OR CHANGE LETTER FORMATTING WITH ** AND SIMILAR. "
+    "YOU ARE USED IN A TEXT PROCESSING PYTHON PROGRAM SO THE TEXT SHOULD BE PLAIN. "
+)
+
+# Define what gets imported when using 'from project_config import *'
+__all__ = [
+    "PROJECT_ROOT",
+    "PROGRESS_FILE",
+    "DIR_FILE",
+    "SUBJECT_FILE",
+    "TASKS_JSON",
+    "EXAM_CODES_JSON",
+    "EXAM_CODES_MERGED_JSON",
+    "IMG_DIR",
+    "PDF_DIR",
+    "PROMPT_CONFIG",
+]

--- a/scripts/project_paths.py
+++ b/scripts/project_paths.py
@@ -1,3 +1,0 @@
-from pathlib import Path
-
-PROJECT_ROOT = Path(__file__).resolve().parent

--- a/scripts/prompttotext.py
+++ b/scripts/prompttotext.py
@@ -4,18 +4,15 @@ import asyncio
 import contextvars
 from openai import OpenAI  # Using OpenAI SDK for DeepSeek
 import builtins
-from project_paths import PROJECT_ROOT
-
-# Definer sti for progress.txt
-progress_file = PROJECT_ROOT / "progress.txt"
+from project_config import *
 
 def update_progress_line3(value="1"):
     """
     Oppdaterer kun linje 3 i progress.txt med den angitte verdien.
     """
     try:
-        if progress_file.exists():
-            with open(progress_file, "r", encoding="utf-8") as f:
+        if PROGRESS_FILE.exists():
+            with open(PROGRESS_FILE, "r", encoding="utf-8") as f:
                 lines = f.readlines()
         else:
             lines = []
@@ -23,11 +20,11 @@ def update_progress_line3(value="1"):
             lines += ["\n"] * (3 - len(lines))
         # Linje 3 er indeks 2
         lines[2] = f"{value}\n"
-        with open(progress_file, "w", encoding="utf-8") as f:
+        with open(PROGRESS_FILE, "w", encoding="utf-8") as f:
             f.writelines(lines)
-        print(f"[STATUS] | Updated line 3 of {progress_file} with '{value}'")
+        print(f"[STATUS] | Updated line 3 of {PROGRESS_FILE} with '{value}'")
     except Exception as e:
-        print(f"[ERROR] Could not update line 3 in {progress_file}: {e}")
+        print(f"[ERROR] Could not update line 3 in {PROGRESS_FILE}: {e}")
 
 # Context variables for task-ID og processing step
 current_task = contextvars.ContextVar("current_task", default="")

--- a/scripts/purge_temaer.py
+++ b/scripts/purge_temaer.py
@@ -4,10 +4,7 @@ Script to purge all "Temaer" lists in ntnu_emner.json by setting each to an empt
 """
 import json
 import sys
-from project_paths import PROJECT_ROOT
-
-# Path to the JSON file
-JSON_PATH = PROJECT_ROOT / "ntnu_emner.json"
+from project_config import *
 
 
 def purge_temaer():
@@ -15,7 +12,7 @@ def purge_temaer():
     Load the JSON, clear all Temaer, and save back the file.
     """
     try:
-        with JSON_PATH.open('r', encoding='utf-8') as f:
+        with EXAM_CODES_JSON.open('r', encoding='utf-8') as f:
             data = json.load(f)
     except Exception as e:
         print(f"❌ Error reading JSON: {e}", file=sys.stderr)
@@ -26,13 +23,13 @@ def purge_temaer():
         entry['Temaer'] = []
 
     try:
-        with JSON_PATH.open('w', encoding='utf-8') as f:
+        with EXAM_CODES_JSON.open('w', encoding='utf-8') as f:
             json.dump(data, f, ensure_ascii=False, indent=4)
     except Exception as e:
         print(f"❌ Error writing JSON: {e}", file=sys.stderr)
         sys.exit(1)
 
-    print(f"✅ All Temaer fields in '{JSON_PATH.name}' have been purged.")
+    print(f"✅ All Temaer fields in '{EXAM_CODES_JSON.name}' have been purged.")
 
 
 if __name__ == '__main__':

--- a/scripts/tasksegmenter.py
+++ b/scripts/tasksegmenter.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import sys
 import prompttotext
 import difflib
+from project_config import *
 
 sys.stdout.reconfigure(encoding='utf-8')
 
@@ -14,12 +15,6 @@ if not json_path or not os.path.exists(json_path):
     raise FileNotFoundError(f"[ERROR] JSON path not found or invalid: {json_path}")
 os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = json_path
 
-nonchalant = (
-    "DO AS YOU ARE TOLD AND RESPOND ONLY WITH WHAT IS ASKED FROM YOU. "
-    "DO NOT EXPLAIN OR SAY WHAT YOU ARE DOING (e.g. here is the..., below is..., sure here is..., etc.). "
-    "DO NOT WRITE ANY SYMBOLS LIKE - OR \n OR CHANGE LETTER FORMATTING WITH ** AND SIMILAR. "
-    "YOU ARE USED IN A TEXT PROCESSING PYTHON PROGRAM SO THE TEXT SHOULD BE PLAIN. "
-)
 
 def detect_text(image_content):
     try:
@@ -69,7 +64,7 @@ async def perform_ocr(images):
 
 async def detect_task_markers(full_text: str):
     prompt = (
-        nonchalant +
+        PROMPT_CONFIG +
         "The provided text is extracted from a multi-page document, with each page clearly marked as === PAGE x ===. "
         "Identify distinctive markers or short introductory phrases that reliably signal the start of each new task or subtask. "
         "Provide each marker as the full beginning phrase (5-15 words) separated by commas. Do not include page markers like === PAGE x ===. "


### PR DESCRIPTION
## Summary
- rename `project_paths.py` to `project_config.py`
- provide `PROMPT_CONFIG` and export all constants
- update imports to new config module
- use constants directly instead of redundant local variables

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68443cf6faf483269e8ac3709b1d8613