### PR TITLE
Improve container-based task detection

### DIFF
--- a/scripts/pdf_contents.py
+++ b/scripts/pdf_contents.py
@@ -1,46 +1,145 @@
-# ----- STEPS -----
-# 1. Make a list of all containers in the PDF.
-# 2. For each container, store its position, and store the text inside it (directly if its a text container, or by OCR if it's an image).
-# 3. Place all the text from the containers into a single string, very clearly marking the start of each container with a comment like "=== CONTAINER x ===" where x is the container number.
-# 4. Prompt the LLM with this string to identify task markers, which is the coordinate of the container that starts a task or subtask, or ends a task - always before the potential løsningsforslag.
-# 5. Draw the lines in the PDF at the identified coordinates.
-# 6. Save the modified PDF.
+"""Utility to identify task boundaries in a PDF.
 
-pdf_dir = "F:\OCRacle\pdf\mast2200.pdf"
+Steps performed:
+1. Iterate over all text and image containers in the PDF.
+2. Extract text from each container using direct extraction or Google Vision
+   OCR for images.
+3. Combine the text with markers ``=== CONTAINER x ===`` so the LLM can refer
+   to specific containers by number.
+4. Ask DeepSeek, in manageable container batches, which containers denote the
+   start or end of tasks.
+5. Return the resulting list of container indices (these can later be used to
+   draw separating lines in the PDF).
+"""
 
-import fitz  # PyMuPDF
+import os
 import asyncio
 from pathlib import Path
+from typing import List, Dict
 
-# List containers in a PDF, only y-coordinate (rounded), type, page, and container number
-async def list_pdf_containers(pdf_path):
-    containers = []
+import fitz  # PyMuPDF
+from google.cloud import vision
+
+import prompt_to_text
+from project_config import PROMPT_CONFIG
+
+PDF_PATH = "F:\\OCRacle\\pdf\\mast2200.pdf"
+
+
+json_path = os.getenv("OCRACLE_JSON_PATH")
+if not json_path or not os.path.exists(json_path):
+    raise FileNotFoundError(f"[ERROR] JSON path not found or invalid: {json_path}")
+os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = json_path
+
+
+def detect_text(image_content: bytes) -> str:
+    """Run Google Vision OCR on the given image bytes."""
     try:
-        doc = fitz.open(pdf_path)
-        for page_num in range(len(doc)):
-            page = doc[page_num]
-            blocks = page.get_text("dict")["blocks"]
-            for block in blocks:
-                y_coord = round(block["bbox"][1])  # y0 (top) coordinate, rounded
-                if "lines" in block:  # Text block
-                    containers.append({
-                        "type": "text",
-                        "page": page_num + 1,
-                        "y": y_coord
-                    })
-                elif "image" in block:  # Image block
-                    containers.append({
-                        "type": "image",
-                        "page": page_num + 1,
-                        "y": y_coord
-                    })
-        return containers
+        client = vision.ImageAnnotatorClient()
+        image = vision.Image(content=image_content)
+        response = client.text_detection(image=image)
+        if response.error.message:
+            raise Exception(response.error.message)
+        texts = response.text_annotations
+        return texts[0].description.replace("\n", " ") if texts else ""
     except Exception as e:
-        print(f"[ERROR] Failed to list PDF containers: {e}")
-        return []
-    
-if __name__ == "__main__":
+        print(f"[ERROR] OCR failed: {e}")
+        return ""
 
-    containers = asyncio.run(list_pdf_containers(pdf_dir))
-    for idx, container in enumerate(containers):
-        print(f"CONTAINER {idx}: type={container['type']}, page={container['page']}, y={container['y']}")
+
+async def _extract_block_text(page, block) -> str:
+    if "lines" in block:  # text block
+        lines = []
+        for line in block.get("lines", []):
+            parts = [span.get("text", "") for span in line.get("spans", [])]
+            lines.append(" ".join(parts))
+        return " ".join(lines).strip()
+    if "image" in block or block.get("type") == 1:  # image block
+        try:
+            clip = fitz.Rect(block["bbox"])
+            pix = page.get_pixmap(clip=clip, dpi=300)
+            img_bytes = pix.tobytes("png")
+            return await asyncio.to_thread(detect_text, img_bytes)
+        except Exception as e:
+            print(f"[WARNING] Failed to OCR image block: {e}")
+    return ""
+
+
+async def list_pdf_containers(pdf_path: str) -> List[Dict]:
+    """Return a list of containers with coordinates and extracted text."""
+    containers: List[Dict] = []
+    doc = fitz.open(pdf_path)
+    total_pages = len(doc)
+    for page_num in range(total_pages):
+        page = doc[page_num]
+        blocks = page.get_text("dict")["blocks"]
+        print(f"[INFO] Processing page {page_num + 1}/{total_pages} with {len(blocks)} blocks")
+        for block in blocks:
+            x0, y0, x1, y1 = block["bbox"]
+            width = x1 - x0
+            height = y1 - y0
+            if width < 20 or height < 8:
+                continue
+            y_coord = round(y0)
+            c = {
+                "page": page_num + 1,
+                "y": y_coord,
+            }
+            if "lines" in block:
+                c["type"] = "text"
+            elif "image" in block or block.get("type") == 1:
+                c["type"] = "image"
+            else:
+                continue
+            c["text"] = await _extract_block_text(page, block)
+            containers.append(c)
+    return containers
+
+
+def build_container_string(containers: List[Dict], start_index: int = 0) -> str:
+    """Return a string with container texts marked by their global index."""
+    parts = []
+    for idx, c in enumerate(containers, start=start_index):
+        parts.append(f"\n\n=== CONTAINER {idx} ===\n{c.get('text', '')}")
+    return "".join(parts)
+
+
+async def query_task_markers(containers: List[Dict], chunk_size: int = 50) -> List[int]:
+    """Query DeepSeek to find task boundary containers."""
+    hits: List[int] = []
+    for start in range(0, len(containers), chunk_size):
+        end = min(start + chunk_size, len(containers))
+        print(f"[INFO] Querying containers {start}-{end-1}")
+        chunk_text = build_container_string(containers[start:end], start_index=start)
+        prompt = (
+            PROMPT_CONFIG
+            + f"Which of these [{start}-{end-1}] containers indicate that a new task is starting or ending?\n"
+            "Reply only with the container number(s) separated by a comma.\n"
+            "Containers are marked with '=== CONTAINER x ===' followed by their text.\n"
+            + chunk_text
+        )
+        resp = await prompt_to_text.async_prompt_to_text(
+            prompt, max_tokens=2000, isNum=False, maxLen=1000
+        )
+        if resp:
+            for tok in str(resp).replace("CONTAINER", "").split(","):
+                tok = tok.strip()
+                if tok.isdigit():
+                    hits.append(int(tok))
+    return sorted(set(hits))
+
+
+async def main_async(pdf_path: str):
+    containers = await list_pdf_containers(pdf_path)
+    print(f"[INFO] Extracted {len(containers)} containers")
+    markers = await query_task_markers(containers)
+    print("Task marker containers:", markers)
+
+
+def main(path: str = PDF_PATH):
+    asyncio.run(main_async(path))
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- refine `pdf_contents.py` to skip tiny containers and show page progress
- mark containers with their global index when building text chunks
- enhance DeepSeek prompt and print query range

## Testing
- `python -m py_compile scripts/pdf_contents.py`

------
https://chatgpt.com/codex/tasks/task_e_6844a2c2eab08326bb350c1e67eaf098