### PR TITLE
Fix extract_images call

### DIFF
--- a/scripts/task_processing.py
+++ b/scripts/task_processing.py
@@ -241,13 +241,11 @@ async def get_exam_info(ocr_text: str) -> Exam:
     global total_tasks
     total_tasks = exam.total_tasks
 
-    await extract_images.extract_images(
+    await extract_images.extract_images_with_tasks(
         pdf_path=pdf_dir,
         subject=exam.subject,
         version=exam.exam_version,
-        total_tasks=exam.total_tasks,
-        full_text=ocr_text,
-        output_folder=None
+        output_folder=None,
     )
 
     return exam


### PR DESCRIPTION
## Summary
- call `extract_images_with_tasks` in `task_processing`

## Testing
- `PYTHONPATH=scripts python scripts/test_process.py` *(fails: No module named 'pytesseract')*

------
https://chatgpt.com/codex/tasks/task_e_6846f25427a4832696b330556cf531fc