### PR TITLE
Fix image storage and web display

### DIFF
--- a/scripts/extract_images.py
+++ b/scripts/extract_images.py
@@ -124,11 +124,13 @@ def _make_saver(output_folder: str, subject: str, version: str, counts: Dict[str
     os.makedirs(exam_folder, exist_ok=True)
 
     def _save(img: np.ndarray, task_num: str):
+        task_folder = os.path.join(exam_folder, task_num)
+        os.makedirs(task_folder, exist_ok=True)
         counts[task_num] = counts.get(task_num, 0) + 1
         seq = counts[task_num]
         fname = f"{subject}_{version}_{task_num}_{seq}.png"
-        cv2.imwrite(os.path.join(exam_folder, fname), img)
-        print(f"Saved {subject}/{version}/{fname}")
+        cv2.imwrite(os.path.join(task_folder, fname), img)
+        print(f"Saved {subject}/{version}/{task_num}/{fname}")
 
     return _save
 

--- a/scripts/project_config.py
+++ b/scripts/project_config.py
@@ -13,7 +13,7 @@ IGNORED_FILE = ICP_DATA_DIR / "ignored.txt"
 TASKS_JSON = PROJECT_ROOT / "tasks.json"
 EXAM_CODES_JSON = PROJECT_ROOT / "ntnu_emner.json"
 
-IMG_DIR = PROJECT_ROOT / "img"
+IMG_DIR = PROJECT_ROOT / "scripts" / "img"
 PDF_DIR = PROJECT_ROOT / "pdf"
 
 PROMPT_CONFIG = (

--- a/scripts/task_processing.py
+++ b/scripts/task_processing.py
@@ -432,7 +432,7 @@ async def process_task(task_number: str, ocr_text: str, exam: Exam) -> Exam:
                     task_dir = IMG_DIR / task_exam.subject / task_exam.exam_version / task_number
                     if task_dir.exists():
                         found_images = sorted(task_dir.glob("*.png"))
-                        task_exam.images = [str(img) for img in found_images]
+                        task_exam.images = [str(img.relative_to(PROJECT_ROOT)) for img in found_images]
                     else:
                         task_exam.images = []
                     print(f"[DEEPSEEK] | Found {len(task_exam.images)} images for task {task_number}.")
@@ -518,19 +518,7 @@ async def main_async(ocr_text: str):
     failed = [res.task_number for res in results if res.task_text is None]
     points = [res.points for res in results if res.task_text is not None]
 
-    # Slett alle bilder i IMG_DIR som ikke er knyttet til noen oppgave
-    used_images = set()
-    for res in results:
-        if res.images:
-            used_images.update(res.images)
-
-    for img_file in IMG_DIR.rglob("*.png"):
-        if str(img_file) not in used_images:
-            try:
-                img_file.unlink()
-                print(f"[CLEANUP] | Deleted unused image: {img_file}")
-            except Exception as e:
-                print(f"[CLEANUP ERROR] | Could not delete {img_file}: {e}")
+    # Bilder beholdes for fremtidig bruk og slettes ikke automatisk
 
     for res in results:
         if res.task_text is not None:

--- a/web/oppgavetester.html
+++ b/web/oppgavetester.html
@@ -72,7 +72,7 @@
     const taskSelect = document.getElementById("task");
     const taskTextDiv = document.getElementById("task_text");
 
-    const relativePath = '../../scripts/tasks.json';
+    const relativePath = '../tasks.json';
 
     fetch(relativePath)
       .then(response => {
@@ -154,22 +154,14 @@
             const imgContainer = document.createElement("div");
 
             images.forEach(imgPath => {
-              const match = imgPath.match(/scripts[\\/](.+)/);
-              const relative = match ? match[1].replace(/\\/g, "/") : null;
-
-              console.log("Relativ sti:", relative);
-
-              if (relative) {
-                const img = document.createElement("img");
-                img.src = `../../scripts/${relative}`;
-                img.alt = "Bilde til oppgave";
-                img.onerror = () => {
-                  console.warn("Kunne ikke laste bilde:", img.src);
-                };
-                imgContainer.appendChild(img);
-              } else {
-                console.warn("Klarte ikke å generere relativ sti:", imgPath);
-              }
+              const normalized = imgPath.replace(/\\/g, "/");
+              const img = document.createElement("img");
+              img.src = `../${normalized}`;
+              img.alt = "Bilde til oppgave";
+              img.onerror = () => {
+                console.warn("Kunne ikke laste bilde:", img.src);
+              };
+              imgContainer.appendChild(img);
             });
 
             taskTextDiv.appendChild(imgContainer);


### PR DESCRIPTION
## Summary
- store extracted images in per-task folders
- keep images under `scripts/img`
- keep images after processing
- expose relative image paths in `tasks.json`
- update web page to load data and images relative to repo root

## Testing
- `python3 -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6846f53d553c8326a568be6f606ee64c