### PR TITLE
Refactor exam version handling and topic storage

### DIFF
--- a/scripts/object_to_json.py
+++ b/scripts/object_to_json.py
@@ -26,18 +26,35 @@ def main(tasks):
             continue
 
         subject_data = existing.setdefault(subject, {})
-        exam_data = subject_data.setdefault(exam, {
-            "total_tasks": task_dict.get("total_tasks", []),
-            "matching_codes": task_dict.get("matching_codes", []),
-            "tasks": []
-        })
+        exam_data = subject_data.setdefault(
+            exam,
+            {
+                "total_tasks": task_dict.get("total_tasks", []),
+                "matching_codes": task_dict.get("matching_codes", []),
+                "exam_topics": task_dict.get("exam_topics", []),
+                "tasks": [],
+            },
+        )
 
         if task_dict.get("total_tasks"):
             exam_data["total_tasks"] = task_dict["total_tasks"]
         if task_dict.get("matching_codes"):
             exam_data["matching_codes"] = task_dict["matching_codes"]
+        if task_dict.get("exam_topics"):
+            exam_data["exam_topics"] = task_dict["exam_topics"]
 
-        task_copy = {k: v for k, v in task_dict.items() if k not in {"subject", "exam_version", "total_tasks", "matching_codes"}}
+        task_copy = {
+            k: v
+            for k, v in task_dict.items()
+            if k
+            not in {
+                "subject",
+                "exam_version",
+                "total_tasks",
+                "matching_codes",
+                "exam_topics",
+            }
+        }
         task_num = task_copy.get("task_number") or 0
 
         tasks_list = exam_data["tasks"]


### PR DESCRIPTION
## Summary
- store exam topics on the exam release rather than on every task
- abbreviate exam version and use the short form everywhere
- simplify topic selection prompt

## Testing
- `python -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6849896f5d94832686720a098b84810e