### PR TITLE
Add prompt tuning utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ I `progress.txt` skrives følgende informasjon fra Python, som oppdaterer GUI-et
  - `ocr_pdf.py` – bruker Google Vision API til å lese PDF som bilder og hente tekst
  - `text_normalization.py` – renser opp i artifacts og symboler etter OCR
 - `cachetask.py` – brukt under utvikling for å teste DeepSeek uten ny OCR
- - `prompt_to_text.py` – sender prompts til DeepSeek og henter svar
- - `task_processing.py` – styrer hele prompt-prosessen og bygger oppgaveobjekter
- - `object_to_json.py` – lagrer oppgaveobjektene til `tasks.json` i
-   strukturen `emne -> eksamensutgivelse -> oppgave`
+- `prompt_to_text.py` – sender prompts til DeepSeek og henter svar
+- `task_processing.py` – styrer hele prompt-prosessen og bygger oppgaveobjekter
+- `object_to_json.py` – lagrer oppgaveobjektene til `tasks.json` i
+  strukturen `emne -> eksamensutgivelse -> oppgave`
+- `prompt_tuning.py` – itererer over ulike prompts og plottar treffprosenten for
+  å finne best mulig formulering
 
 ## Start av Python-arbeidsflyten
 Python-delen startes med
@@ -108,6 +110,7 @@ tqdm
 transformers
 requests
 scipy
+matplotlib
 PyMuPDF
 pdf2image
 PyPDF2

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ PyMuPDF  # Includes fitz
 openai
 requests
 scipy
+matplotlib

--- a/scripts/prompt_tuning.py
+++ b/scripts/prompt_tuning.py
@@ -1,0 +1,81 @@
+import argparse
+from difflib import SequenceMatcher
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
+import prompt_to_text
+from project_config import PROMPT_CONFIG
+
+
+def match_percent(a: str, b: str) -> float:
+    """Return percent similarity between two strings."""
+    return SequenceMatcher(None, a.lower(), b.lower()).ratio() * 100
+
+
+def refine_prompt(current_prompt: str, input_text: str, output_text: str, target: str) -> str:
+    """Use DeepSeek to suggest a better prompt."""
+    instruction = (
+        f"{PROMPT_CONFIG}Vi prøver å løse teksten '{input_text}'. "
+        f"Den gjeldende prompten er: '{current_prompt}'. "
+        f"Svaret ble: '{output_text}'. "
+        f"Målet er noe som ligner: '{target}'. "
+        "Gi en intuitiv forbedring av prompten uten å sitere eller be om eksakt tekst. "
+        "Svar kun med selve prompten."
+    )
+    suggestion = prompt_to_text.prompt_to_text(
+        instruction, max_tokens=200, isNum=False, maxLen=400
+    )
+    return suggestion if suggestion else current_prompt
+
+
+def tune_prompt(initial_prompt: str, input_text: str, target: str, iterations: int = 5):
+    prompts = [initial_prompt]
+    outputs = []
+    matches = []
+    current_prompt = initial_prompt
+
+    for i in range(iterations):
+        print(f"\n--- Iterasjon {i + 1} ---")
+        full_prompt = f"{PROMPT_CONFIG}{current_prompt}\n\n{input_text}"
+        out = prompt_to_text.prompt_to_text(
+            full_prompt, max_tokens=800, isNum=False, maxLen=1500
+        )
+        out = out or ""
+        outputs.append(out)
+        match = match_percent(out, target)
+        matches.append(match)
+        print(f"Match: {match:.2f}%\nOutput: {out}\n")
+        current_prompt = refine_prompt(current_prompt, input_text, out, target)
+        prompts.append(current_prompt)
+
+    plt.figure()
+    plt.plot(range(1, iterations + 1), matches, marker="o")
+    plt.xlabel("Iterasjon")
+    plt.ylabel("Match %")
+    plt.title("Prompt tuning")
+    plt.ylim(0, 100)
+    plt.grid(True)
+    plot_path = "prompt_tuning_plot.png"
+    plt.savefig(plot_path)
+    print(f"Plot lagret til {plot_path}")
+
+    return prompts, outputs, matches
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Automatisk prompttuning")
+    parser.add_argument("--prompt", default="Løs denne oppgaven")
+    parser.add_argument("--input_text", default="x**2 + 8x + 16 = 0")
+    parser.add_argument(
+        "--target_text",
+        default="Vi benytter abc-formelen og setter a=1, b=8 og c=16.",
+    )
+    parser.add_argument("--iterations", type=int, default=5)
+    args = parser.parse_args()
+
+    tune_prompt(args.prompt, args.input_text, args.target_text, args.iterations)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a script `prompt_tuning.py` that iteratively improves prompts
- include new tool in README and mention that matplotlib is required
- add `matplotlib` to requirements

## Testing
- `python scripts/prompt_tuning.py --help` *(fails: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_6849cc0337a4832699a2c3c947248c7e