### PR TITLE
Improve readability of prompts

### DIFF
--- a/prompts/detect_images.txt
+++ b/prompts/detect_images.txt
@@ -1,2 +1,4 @@
-MAKE SURE YOU ONLY RESPOND WITH 0 OR 1!!! Does this task likely contain any images or figures that are relevant for solving the task? Respond with 1 if you think there are images, 0 if not. Only reply with 0 or 1, nothing else. 
-
+MAKE SURE YOU ONLY RESPOND WITH 0 OR 1!!!
+  Does this task likely contain any images or figures that are relevant for solving the task?
+  Respond with 1 if you think there are images, 0 if not.
+  Only reply with 0 or 1, nothing else.

--- a/prompts/extract_points.txt
+++ b/prompts/extract_points.txt
@@ -1,2 +1,3 @@
-MAKE SURE YOU ONLY RESPOND WITH A NUMBER!!! How many points can you get for this task? Only reply with the number of points, nothing else: 
-
+MAKE SURE YOU ONLY RESPOND WITH A NUMBER!!!
+  How many points can you get for this task?
+  Only reply with the number of points, nothing else:

--- a/prompts/extract_task_text.txt
+++ b/prompts/extract_task_text.txt
@@ -1,2 +1,6 @@
-What is task {task_number}? Write only all text that is required for solving that one TASK or SUBTASK from the raw text. If the task is a subtask (e.g. 1a), only include the text related to solving that subtask, not the full task, but be sure to have what is necessary for solving the task. Include the topic (if there is one in the title) of the task and how many maximum points you can get. Do not include the solution to the task. If the text is written in multiple languages, respond with the text in norwegian bokmål. 
-
+What is task {task_number}?
+  Write only all text that is required for solving that one TASK or SUBTASK from the raw text.
+  If the task is a subtask (e.g. 1a), only include the text related to solving that subtask, not the full task, but be sure to have what is necessary for solving the task.
+  Include the topic (if there is one in the title) of the task and how many maximum points you can get.
+  Do not include the solution to the task.
+  If the text is written in multiple languages, respond with the text in norwegian bokmål.

--- a/prompts/extract_topic.txt
+++ b/prompts/extract_topic.txt
@@ -1,2 +1,3 @@
-Velg temaet til denne oppgaven fra listen under. Svar kun med temaet på norsk bokmål, ingenting annet. Her kommer listen og deretter oppgaveteksten: 
-
+Velg temaet til denne oppgaven fra listen under.
+  Svar kun med temaet på norsk bokmål, ingenting annet.
+  Her kommer listen og deretter oppgaveteksten:

--- a/prompts/format_html_output.txt
+++ b/prompts/format_html_output.txt
@@ -1,31 +1,31 @@
-Format this exam task as a valid HTML string for use in a JavaScript variable. Here are a couple rules to follow:
-- Use <p>...</p> for all text paragraphs.
-- Use <h3>a)</h3>, <h3>b)</h3> etc for subtask labels if present.
-- Use MathJax-compatible LaTeX.
-- Wrap display math in $$...$$.
-- Wrap inline math in $...$.
-- Use a single backslash for LaTeX commands (e.g., \frac, \sqrt).
-- Do not use \( ... \) or \[ ... \].
-- Do not double-escape backslashes.
-- Do not explain, summarize, or add anything outside the HTML.
-- Output must be usable directly inside const oppgaveTekst = `<the content here>`.
-- Do not add any other text or explanation.
-- Do not add any HTML tags outside the <p>...</p> and <h3>...</h3> tags.
-- Make sure that e.g. infty, omega, theta, etc. are properly formatted.
-- Do not write the result as you would write in a programming box, but as you would write it as clean text.
-- Do not include ```html or const oppgaveTekst = `` or similar.
-- You are allowed to make som assumptions about OCR artifacts in the text, such as \sqrt{\sqrt{\sqrt most likely being an error for a single square root.
-- Be sure to include spaces and newlines where appropriate, the formatting is supposed to look proper.
+Format this exam task as a valid HTML string for use in a JavaScript variable.
+Here are a couple rules to follow:
+  - Use <p>...</p> for all text paragraphs.
+  - Use <h3>a)</h3>, <h3>b)</h3> etc for subtask labels if present.
+  - Use MathJax-compatible LaTeX.
+  - Wrap display math in $$...$$.
+  - Wrap inline math in $...$.
+  - Use a single backslash for LaTeX commands (e.g., \frac, \sqrt).
+  - Do not use \( ... \) or \[ ... \].
+  - Do not double-escape backslashes.
+  - Do not explain, summarize, or add anything outside the HTML.
+  - Output must be usable directly inside const oppgaveTekst = `<the content here>`.
+  - Do not add any other text or explanation.
+  - Do not add any HTML tags outside the <p>...</p> and <h3>...</h3> tags.
+  - Make sure that e.g. infty, omega, theta, etc. are properly formatted.
+  - Do not write the result as you would write in a programming box, but as you would write it as clean text.
+  - Do not include ```html or const oppgaveTekst = `` or similar.
+  - You are allowed to make som assumptions about OCR artifacts in the text, such as \sqrt{\sqrt{\sqrt most likely being an error for a single square root.
+  - Be sure to include spaces and newlines where appropriate, the formatting is supposed to look proper.
 
 For multiple choice tasks with text or image alternatives, also follow these rules:
-- Present the alternatives as an ordered list using <ol><li>.
-- Prefix each alternative with the corresponding letter label inside <b> tags (A, B, C, ...).
-- If an alternative contains an image, use <img src='PATH' alt=''> within the <li> element.
-- Keep the statement of the task itself outside the list in normal <p> tags.
+  - Present the alternatives as an ordered list using <ol><li>.
+  - Prefix each alternative with the corresponding letter label inside <b> tags (A, B, C, ...).
+  - If an alternative contains an image, use <img src='PATH' alt=''> within the <li> element.
+  - Keep the statement of the task itself outside the list in normal <p> tags.
 
 For regular tasks that require proving, calculating or explaining, also follow these rules:
-- Keep paragraphs short and use multiple <p> elements rather than a single long block.
-- Introduce each subtask with its label using <h3>a)</h3>, <h3>b)</h3> and so on.
+  - Keep paragraphs short and use multiple <p> elements rather than a single long block.
+  - Introduce each subtask with its label using <h3>a)</h3>, <h3>b)</h3> and so on.
 
 Here is the task text:
-

--- a/prompts/get_exam_version.txt
+++ b/prompts/get_exam_version.txt
@@ -1,2 +1,8 @@
-What exam edition is this exam? Respond only with the singular formatted exam edition written in norwegian. If the exam is in the spring or early summer, it should be titled Vår 20XX. If the exam is in the autumn or early winter, it should be titled Høst 20XX. If the exam is in the late summer or early autumn, it should be titled Kont 20XX. Of course 20XX is just an example here, write the actual year. The title of the pdf is {pdf_dir} which might help you, or not. Make an educated guess from all the information above collectively. 
-
+What exam edition is this exam?
+  Respond only with the singular formatted exam edition written in norwegian.
+  If the exam is in the spring or early summer, it should be titled Vår 20XX.
+  If the exam is in the autumn or early winter, it should be titled Høst 20XX.
+  If the exam is in the late summer or early autumn, it should be titled Kont 20XX.
+  Of course 20XX is just an example here, write the actual year.
+  The title of the pdf is {pdf_dir} which might help you, or not.
+  Make an educated guess from all the information above collectively.

--- a/prompts/get_subject_code.txt
+++ b/prompts/get_subject_code.txt
@@ -1,2 +1,6 @@
-What is the subject code for this exam? Respond only with the singular formatted subject code (e.g., IFYT1000). If there are variation in the last letter (e.g. IMAA, IMAG, IMAT), replace the variating letter with an X instead => IMAX. If there are variation in number(s), e.g 2002, 2012, 2022 - replace the variating number(s) with an Y instead => 20Y2. Only replace a number with a letter if the subject code clearly has variations. Here is the text from the OCR: 
-
+What is the subject code for this exam?
+  Respond only with the singular formatted subject code (e.g., IFYT1000).
+  If there are variation in the last letter (e.g., IMAA, IMAG, IMAT), replace the variating letter with an X instead => IMAX.
+  If there are variation in number(s), e.g 2002, 2012, 2022 - replace the variating number(s) with an Y instead => 20Y2.
+  Only replace a number with a letter if the subject code clearly has variations.
+  Here is the text from the OCR:

--- a/prompts/get_total_tasks.txt
+++ b/prompts/get_total_tasks.txt
@@ -1,2 +1,5 @@
-How many tasks are in this text? Respond with each task number separated by a comma. Only include the task number, do not account for subtasks, only the main task number. Do not include any symbols like ) or - or similar. Here is the text: 
-
+How many tasks are in this text?
+  Respond with each task number separated by a comma.
+  Only include the task number, do not account for subtasks, only the main task number.
+  Do not include any symbols like ) or - or similar.
+  Here is the text:

--- a/prompts/remove_exam_admin.txt
+++ b/prompts/remove_exam_admin.txt
@@ -1,2 +1,19 @@
-Remove all text related to Inspera and exam administration. This includes information about the exam, such as: - Denne oppgaven skal besvares i Inspera. Du skal ikke legge ved utregninger på papir. - Skriv enten 1, 2, eller 3 i svarfeltet. - Skriv bare én av bokstavene A, B, C, D, E i hvert felt under. - Skriv ditt svar her, eller bruk scantronark. - Denne oppgaven skal besvares i tekstboksen under, eller ved bruk av scantronark. - Du kan skrive svaret i boksen under, eller skrive på Scantronark som leveres for innskanning. - Vi anbefaler bruk av Scantron-ark. - Nederst i oppgaven finner du en sjusifret kode. Fyll inn denne koden øverst til venstre på arkene du ønsker å levere. - Etter eksamen finner du besvarelsen din i arkivet i Inspera. - Varslinger vil bli gitt via Inspera. - Kontaktinformasjon til faglærer under eksamen. - Hjelpemiddelkoder og kalkulatorliste. - Eksamensdato og klokkeslett. - Rund av til 2 desimalers nøyaktighet // til nærmeste heltall. Also remove the task number (1, Oppgave 1, 1a, a), etc.), max points and title/topic of the task. Do not include the solution to the task, only the task text itself. Be sure to still include ALL the information necessary for being able to solve the task, such as the main question itself. 
-
+Remove all text related to Inspera and exam administration.
+This includes information about the exam, such as:
+  - Denne oppgaven skal besvares i Inspera. Du skal ikke legge ved utregninger på papir.
+  - Skriv enten 1, 2, eller 3 i svarfeltet.
+  - Skriv bare én av bokstavene A, B, C, D, E i hvert felt under.
+  - Skriv ditt svar her, eller bruk scantronark.
+  - Denne oppgaven skal besvares i tekstboksen under, eller ved bruk av scantronark.
+  - Du kan skrive svaret i boksen under, eller skrive på Scantronark som leveres for innskanning.
+  - Vi anbefaler bruk av Scantron-ark.
+  - Nederst i oppgaven finner du en sjusifret kode. Fyll inn denne koden øverst til venstre på arkene du ønsker å levere.
+  - Etter eksamen finner du besvarelsen din i arkivet i Inspera.
+  - Varslinger vil bli gitt via Inspera.
+  - Kontaktinformasjon til faglærer under eksamen.
+  - Hjelpemiddelkoder og kalkulatorliste.
+  - Eksamensdato og klokkeslett.
+  - Rund av til 2 desimalers nøyaktighet // til nærmeste heltall.
+Also remove the task number (1, Oppgave 1, 1a, a), etc.), max points and title/topic of the task.
+Do not include the solution to the task, only the task text itself.
+Be sure to still include ALL the information necessary for being able to solve the task, such as the main question itself.

--- a/prompts/translate_to_bokmaal.txt
+++ b/prompts/translate_to_bokmaal.txt
@@ -1,2 +1,4 @@
-Translate this task text from norwegian nynorsk or english to norwegian bokmål, do not change anything else. If it is already in norwegian bokmål respond with the exact same text. Here is the text: 
-
+Translate this task text from norwegian nynorsk or english to norwegian bokmål,
+  do not change anything else.
+  If it is already in norwegian bokmål respond with the exact same text.
+  Here is the text:

--- a/prompts/validate_task.txt
+++ b/prompts/validate_task.txt
@@ -1,2 +1,2 @@
-MAKE SURE YOU ONLY RESPOND WITH 0 OR 1!!! Answer 1 if this is a valid task that could be in an exam and that can be logically solved, otherwise 0:
-
+MAKE SURE YOU ONLY RESPOND WITH 0 OR 1!!!
+  Answer 1 if this is a valid task that could be in an exam and that can be logically solved, otherwise 0:


### PR DESCRIPTION
## Summary
- format all prompt text files with clearer line breaks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytesseract')*

------
https://chatgpt.com/codex/tasks/task_e_684ae531568c83268f8f199095aca401