### PR TITLE
Refactor task processing logic and rename parameters

### DIFF
--- a/old/emner.py
+++ b/old/emner.py
@@ -42,8 +42,8 @@ async def test_prompt():
         "DONT EVER EXPLAIN OR SAY WHAT YOU ARE DOING. JUST DO AS YOU ARE TOLD AND RESPOND WITH WHAT IS ASKED FROM YOU. "
         "What are the subject codes for this exam? Respond only with codes separated by commas: " + ocrtext,
         max_tokens=100,
-        isNum=False,
-        maxLen=200
+        is_num=False,
+        max_len=200
     )
 
     # Splitt og normaliser
@@ -75,8 +75,8 @@ async def test_prompt():
         result = await prompttotext.async_prompt_to_text(
             prompt,
             max_tokens=2000,
-            isNum=False,
-            maxLen=3000
+            is_num=False,
+            max_len=3000
         )
     except Exception as e:
         print(f"❌ Feil under API-kall: {e}", file=sys.stderr)

--- a/old/extract_images_googlevision_auto.py
+++ b/old/extract_images_googlevision_auto.py
@@ -61,7 +61,7 @@ async def _assign_tasks(containers: List[Dict]) -> Dict[int, str]:
             "Text:" + text
         )
         answer = await prompt_to_text.async_prompt_to_text(
-            prompt, max_tokens=20, isNum=False, maxLen=20
+            prompt, max_tokens=20, is_num=False, max_len=20
         )
         m = TASK_RE.search(str(answer))
         task_num = m.group(2) if m else str(idx)

--- a/old/extract_images_googlevision_tasks.py
+++ b/old/extract_images_googlevision_tasks.py
@@ -161,7 +161,7 @@ async def extract_images(
             "Her er teksten: " + full_text
             )
         res = await prompt_to_text.async_prompt_to_text(
-            prompt, max_tokens=50, isNum=False, maxLen=200
+            prompt, max_tokens=50, is_num=False, max_len=200
         )
         page_tasks = _parse_tasks(str(res), total_tasks)
         if page_tasks == ["0"]:
@@ -205,7 +205,7 @@ async def extract_images(
             img_text = ocr_pdf.detect_text(crop_buf.tobytes())
             verify_prompt = (PROMPT_CONFIG + "Does this text include put-together sentences? Respond 0 if yes, 1 if no. Text: " + img_text)
             v_raw = await prompt_to_text.async_prompt_to_text(
-                verify_prompt, max_tokens=50, isNum=True, maxLen=2
+                verify_prompt, max_tokens=50, is_num=True, max_len=2
             )
             try:
                 img_verify = int(str(v_raw).strip())

--- a/old/taskonpage.py
+++ b/old/taskonpage.py
@@ -49,8 +49,8 @@ async def which_task_on_page(pdf_path: str, page_number: int) -> None:
     result = await prompttotext.async_prompt_to_text(
         prompt,
         max_tokens=50,
-        isNum=False,
-        maxLen=100
+        is_num=False,
+        max_len=100
     )
     print(result)
 

--- a/scripts/extract_images.py
+++ b/scripts/extract_images.py
@@ -99,7 +99,7 @@ async def _assign_tasks(containers: List[Dict]) -> Dict[int, str]:
             "Text:" + text
         )
         answer = await prompt_to_text.async_prompt_to_text(
-            prompt, max_tokens=20, isNum=False, maxLen=20
+            prompt, max_tokens=20, is_num=False, max_len=20
         )
         m = TASK_RE.search(str(answer))
         if m:

--- a/scripts/pdf_contents.py
+++ b/scripts/pdf_contents.py
@@ -109,7 +109,7 @@ def build_container_string(containers: List[Dict]) -> str:
 
 async def _query_markers(prompt: str) -> List[int]:
     resp = await prompt_to_text.async_prompt_to_text(
-        prompt, max_tokens=2000, isNum=False, maxLen=1000
+        prompt, max_tokens=2000, is_num=False, max_len=1000
     )
     return (
         sorted(set(int(tok) for tok in re.findall(r"\d+", str(resp)))) if resp else []

--- a/scripts/prompt_to_text.py
+++ b/scripts/prompt_to_text.py
@@ -54,12 +54,12 @@ def isNumber(a):
 def isType(a, b):
     return type(a) == b
 
-def prompt_to_text(prompt, max_tokens=1000, isNum=True, maxLen=None):
+def prompt_to_text(prompt, max_tokens=1000, is_num=True, max_len=None):
     """
     Synkron funksjon som sender API-kall, beregner tokenbruk og kostnad.
     Prøver opp til 3 ganger til et gyldig svar mottas.
-    Dersom isNum er True, sjekkes det at svaret er numerisk og konverteres til int.
-    Dersom maxLen er angitt og lengden på resultatet (etter strip) overstiger denne,
+    Dersom is_num er True, sjekkes det at svaret er numerisk og konverteres til int.
+    Dersom max_len er angitt og lengden på resultatet (etter strip) overstiger denne,
     skrives "Exceeded max letters" og loopen fortsetter.
     Returnerer None dersom prompten feiler etter 3 forsøk.
     """
@@ -86,10 +86,10 @@ def prompt_to_text(prompt, max_tokens=1000, isNum=True, maxLen=None):
             )
             if response.choices:
                 result_text = response.choices[0].message.content.strip()
-                if maxLen is not None and len(result_text) > maxLen:
+                if max_len is not None and len(result_text) > max_len:
                     print(f"{prefix}[ERROR] Exceeded max letters. (attempt {attempt}/{max_attempts})")
                     continue
-                if isNum:
+                if is_num:
                     if not isNumber(result_text):
                         print(f"{prefix}[ERROR] Expected numeric result. (attempt {attempt}/{max_attempts})")
                         continue
@@ -108,9 +108,9 @@ def prompt_to_text(prompt, max_tokens=1000, isNum=True, maxLen=None):
     print(f"{prefix}[ERROR] Prompt failed after {max_attempts} attempts.")
     return None
 
-async def async_prompt_to_text(prompt, max_tokens=1000, isNum=True, maxLen=None):
+async def async_prompt_to_text(prompt, max_tokens=1000, is_num=True, max_len=None):
     """
     Asynkron wrapper for prompt_to_text med propagasjon av context variables.
     """
     ctx = contextvars.copy_context()
-    return await asyncio.to_thread(ctx.run, prompt_to_text, prompt, max_tokens, isNum, maxLen)
+    return await asyncio.to_thread(ctx.run, prompt_to_text, prompt, max_tokens, is_num, max_len)

--- a/scripts/prompt_tuning_plot.py
+++ b/scripts/prompt_tuning_plot.py
@@ -41,7 +41,7 @@ def refine_prompt(current_prompt: str, input_text: str, output_text: str, target
         "Svar kun med selve prompten."
     )
     suggestion = prompt_to_text.prompt_to_text(
-        instruction, max_tokens=200, isNum=False, maxLen=1500
+        instruction, max_tokens=200, is_num=False, max_len=1500
     )
     return suggestion if suggestion else current_prompt
 
@@ -64,7 +64,7 @@ async def async_refine_prompt(current_prompt: str, input_text: str, output_text:
         "Svar kun med selve prompten."
     )
     suggestion = await prompt_to_text.async_prompt_to_text(
-        instruction, max_tokens=200, isNum=False, maxLen=1500
+        instruction, max_tokens=200, is_num=False, max_len=1500
     )
     return suggestion if suggestion else current_prompt
 
@@ -86,7 +86,7 @@ def tune_prompt(initial_prompt: str, input_text: str, target: str, iterations: i
             f"{input_text}"
         )
         out = prompt_to_text.prompt_to_text(
-            full_prompt, max_tokens=800, isNum=False, maxLen=1500
+            full_prompt, max_tokens=800, is_num=False, max_len=1500
         )
         out = out or ""
         outputs.append(out)
@@ -142,7 +142,7 @@ async def tune_prompts(tasks, iterations: int = 15):
         ]
         outs = await asyncio.gather(
             *[
-                prompt_to_text.async_prompt_to_text(fp, max_tokens=800, isNum=False, maxLen=1500)
+                prompt_to_text.async_prompt_to_text(fp, max_tokens=800, is_num=False, max_len=1500)
                 for fp in full_prompts
             ]
         )

--- a/scripts/tasksegmenter.py
+++ b/scripts/tasksegmenter.py
@@ -73,7 +73,7 @@ async def detect_task_markers(full_text: str):
     )
 
     response = await prompt_to_text.async_prompt_to_text(
-        prompt, max_tokens=2000, isNum=False, maxLen=5000
+        prompt, max_tokens=2000, is_num=False, max_len=5000
     )
     markers = [marker.strip() for marker in response.split(',') if marker.strip()]
 


### PR DESCRIPTION
## Summary
- rename isNum/maxLen arguments to snake case throughout the codebase
- remove `task_process_instructions` and rewrite `process_task` with explicit steps
- update old helper scripts to use the new parameter names

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e9ab4c47c8326b2c9f3d2e37a26b5