### PR TITLE
Improve image-to-task mapping

### DIFF
--- a/scripts/task_processing.py
+++ b/scripts/task_processing.py
@@ -252,6 +252,7 @@ async def get_exam_info(ocr_text: str) -> Exam:
         subject=exam.subject,
         version=exam.exam_version,
         output_folder=None,
+        expected_tasks=exam.total_tasks,
     )
 
 


### PR DESCRIPTION
## Summary
- validate task mapping by randomly sampling container batches
- ensure detected task count matches container grouping
- pass expected tasks from `task_processing` to image extraction

## Testing
- `python -m py_compile scripts/extract_images.py scripts/pdf_contents.py scripts/task_processing.py`
- `python scripts/test_process.py` *(fails: ModuleNotFoundError: No module named 'pytesseract')*

------
https://chatgpt.com/codex/tasks/task_e_684ea10bfad883269db296dabff01420