### PR TITLE
Update file selection workflow

### DIFF
--- a/app/App.h
+++ b/app/App.h
@@ -18,7 +18,8 @@ public:
     App(const std::string& windowName);
 
     void GUI();
-    void pdfHandling();
+    void pdfHandling(TDT4102::TextBox* chosenFile);
+    void startProcessing();
     void calculateProgress();
     void startTimer();
     void stopTimer();


### PR DESCRIPTION
## Summary
- add `startProcessing` method
- update `pdfHandling` to return the selected filename
- start button now launches `startProcessing`
- exam upload button opens file chooser

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytesseract')*
- `meson setup build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854107caefc83269502ab205a8da450