### PR TITLE
Fix task parsing and path handling

### DIFF
--- a/prompts/get_total_tasks.txt
+++ b/prompts/get_total_tasks.txt
@@ -1,5 +1,4 @@
 How many tasks are in this text?
-  Respond with each task number separated by a comma.
-  Only include the task number, do not account for subtasks, only the main task number.
-  Do not include any symbols like ) or - or similar.
+  Respond only with the total number of tasks as a single number.
+  Do not include any symbols or words.
   Here is the text:

--- a/scripts/object_to_json.py
+++ b/scripts/object_to_json.py
@@ -30,14 +30,14 @@ def main(tasks):
         exam_data = subject_data.setdefault(
             exam,
             {
-                "total_tasks": task_dict.get("total_tasks", []),
+                "total_tasks": task_dict.get("total_tasks", 0),
                 "matching_codes": task_dict.get("matching_codes", []),
                 "exam_topics": task_dict.get("exam_topics", []),
                 "tasks": [],
             },
         )
 
-        if task_dict.get("total_tasks"):
+        if task_dict.get("total_tasks") is not None:
             exam_data["total_tasks"] = task_dict["total_tasks"]
         if task_dict.get("matching_codes"):
             exam_data["matching_codes"] = task_dict["matching_codes"]

--- a/scripts/ocr_pdf.py
+++ b/scripts/ocr_pdf.py
@@ -4,6 +4,7 @@ import asyncio
 from google.cloud import vision
 from tqdm import tqdm
 import sys
+from pathlib import Path
 from project_config import *
 import json
 
@@ -120,10 +121,15 @@ async def main_async():
         return ""
 
     pdf_path = dir_data.get("exam", "").strip()
-
-    if not os.path.exists(pdf_path):
-        print(f"[ERROR] File does not exist: {pdf_path}")
+    path_obj = Path(pdf_path)
+    if not path_obj.is_absolute():
+        candidate = PDF_DIR / path_obj
+        if candidate.exists():
+            path_obj = candidate
+    if not path_obj.exists():
+        print(f"[ERROR] File does not exist: {path_obj}")
         return ""
+    pdf_path = str(path_obj)
 
     print(f"\n[INFO] Selected file: {os.path.basename(pdf_path)}\n")
 


### PR DESCRIPTION
## Summary
- update prompt to return number of tasks
- parse number of tasks as integer and iterate accordingly
- make image extraction expect a generated range
- ensure PDF paths work relative to `pdf/`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685536c60364832698fc4c368bf2c7df