### PR TITLE
Refactor task detection

### DIFF
--- a/scripts/extract_images.py
+++ b/scripts/extract_images.py
@@ -130,7 +130,7 @@ async def confirm_task_text(
         ans = await prompt_to_text.async_prompt_to_text(
             prompt, max_tokens=5, is_num=True, max_len=5
         )
-        keep = int(ans) == 1 if ans is not None else True
+        keep = str(ans).strip() == "1"
         status = "KEEP" if keep else "DROP"
         print(f"[CHECK] Range {idx} -> {status} ({ans})")
         if not keep:
@@ -489,6 +489,8 @@ async def extract_images_with_tasks(
 
     doc.close()
 
+    return assigned
+
 
 async def main_async(
     pdf_path: str,
@@ -496,7 +498,7 @@ async def main_async(
     version: str = "1",
     expected_tasks: Optional[List[str]] = None,
 ):
-    await extract_images_with_tasks(pdf_path, subject, version, expected_tasks=expected_tasks)
+    return await extract_images_with_tasks(pdf_path, subject, version, expected_tasks=expected_tasks)
 
 
 if __name__ == "__main__":

--- a/scripts/object_to_json.py
+++ b/scripts/object_to_json.py
@@ -54,6 +54,7 @@ def main(tasks):
                 "total_tasks",
                 "matching_codes",
                 "exam_topics",
+                "task_numbers",
             }
         }
         task_num = task_copy.get("task_number") or 0


### PR DESCRIPTION
## Summary
- add `task_numbers` to `Exam` dataclass
- check task batches more strictly
- return detected task list from image extractor
- compute number of tasks from PDF containers instead of prompting
- iterate through detected task numbers when processing tasks
- ignore `task_numbers` when writing JSON

## Testing
- `python -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685539bcb75883269ad3647fdb641f79