### PR TITLE
Implement working progress bars

### DIFF
--- a/app/App.h
+++ b/app/App.h
@@ -51,9 +51,9 @@ public:
 
     TDT4102::TextInput *ignoredTopics;
 
+    ProgressBar *ProgressBarIdentify = nullptr;
     ProgressBar *ProgressBarOCR = nullptr;
     ProgressBar *ProgressBarLLM = nullptr;
-    ProgressBar *ProgressBarIMG = nullptr;
 
     TDT4102::Image *ntnuLogo = nullptr;
     int *ntnuLogoScale = nullptr;

--- a/scripts/task_boundaries.py
+++ b/scripts/task_boundaries.py
@@ -2,7 +2,7 @@ import asyncio
 import io
 import re
 from pathlib import Path
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Tuple, Optional, Callable
 from utils import log
 
 import fitz
@@ -192,7 +192,14 @@ async def detect_task_boundaries(pdf_path: str, expected_tasks: Optional[List[st
 
 
 
-def crop_tasks(pdf_path: str, containers: List[Dict], ranges: List[Tuple[int, int]], task_numbers: List[str], temp_dir: Optional[str] = None) -> List[Tuple[str, bytes]]:
+def crop_tasks(
+    pdf_path: str,
+    containers: List[Dict],
+    ranges: List[Tuple[int, int]],
+    task_numbers: List[str],
+    temp_dir: Optional[str] = None,
+    progress_callback: Optional[Callable[[int], None]] = None,
+) -> List[Tuple[str, bytes]]:
     """Crop image regions for each task and return them as bytes.
 
     Each returned tuple contains the task number and the PNG bytes for a page
@@ -225,6 +232,8 @@ def crop_tasks(pdf_path: str, containers: List[Dict], ranges: List[Tuple[int, in
                     f.write(img_bytes)
                 # Uncomment for debugging
                 # log(f"Wrote debug image {fname}")
+        if progress_callback:
+            progress_callback(idx)
     doc.close()
     return output
 


### PR DESCRIPTION
## Summary
- show progress for identifying tasks, OCR, and LLM processing
- track LLM step count via progress.json
- expose task identification progress from Python
- adjust App to read new fields and update bars

## Testing
- `python -m py_compile scripts/task_processing.py scripts/task_boundaries.py`
- `meson setup build > /tmp/meson.log && ninja -C build > /tmp/ninja.log` *(fails: meson not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685926805a8c8326b9c349be17431d59