### PR TITLE
Fix progress file handling

### DIFF
--- a/scripts/ocr_pdf.py
+++ b/scripts/ocr_pdf.py
@@ -23,9 +23,6 @@ if not json_path or not os.path.exists(json_path):
 os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = json_path
 log(f"Authenticated Google Vision API ({Path(json_path).name})")
 
-# Definer sti for progress.json and empty file at startup
-with open(PROGRESS_FILE, "w", encoding="utf-8") as f:
-    json.dump({}, f)
 
 def _read_progress() -> dict:
     if PROGRESS_FILE.exists():


### PR DESCRIPTION
## Summary
- don't clear progress.json when importing OCR logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6859cca734d08326b4d179cc936e8750