### PR TITLE
Fix LLM progress bar

### DIFF
--- a/app/App.cpp
+++ b/app/App.cpp
@@ -77,8 +77,7 @@ void App::GUI() {
 
 
     ProgressBarIdentify = new ProgressBar(*this, App::pad + 4, App::pad*16, "Identifying tasks");
-    ProgressBarOCR = new ProgressBar(*this, App::pad + 4, App::pad*19, "OCR processing");
-    ProgressBarLLM = new ProgressBar(*this, App::pad + 4, App::pad*22, "LLM processing");
+    ProgressBarLLM = new ProgressBar(*this, App::pad + 4, App::pad*19, "LLM processing");
 
     ntnuLogo = new TDT4102::Image("ntnu_logo.png");
     ntnuLogoScale = new int(10);
@@ -128,7 +127,6 @@ void App::GUI() {
 
 void App::update() {
     ProgressBarIdentify->setCount();
-    ProgressBarOCR->setCount();
     ProgressBarLLM->setCount();
     this->draw_image({pad * 5 + static_cast<int>(buttonWidth) * 4 + 6, pad * 2 + static_cast<int>(buttonHeight) / 3}, *ntnuLogo, ntnuLogo->width/ *ntnuLogoScale, ntnuLogo->height/ *ntnuLogoScale);
 }
@@ -315,11 +313,10 @@ void App::startProcessing() {
 }
 
 // Map for lesing av tekstfilen
-std::string ocrLine, taskLine, GoogleVisionIndicatorLine, DeepSeekIndicatorLine, examSubjectLine, examVersionLine, examAmountLine, identifyLine;
+std::string taskLine, GoogleVisionIndicatorLine, DeepSeekIndicatorLine, examSubjectLine, examVersionLine, examAmountLine, identifyLine;
 int taskSteps = 8;
 const std::map<int, std::string*> ProgressLineMap = {
     {1, &GoogleVisionIndicatorLine},
-    {2, &ocrLine},
     {3, &DeepSeekIndicatorLine},
     {4, &taskLine},
     {5, &examSubjectLine},
@@ -366,12 +363,12 @@ void App::calculateProgress() {
                                 jdata[(*it)[1].str()] = (*it)[2].str();
                             }
 
-                            for (int i = 1; i <= static_cast<int>(ProgressLineMap.size()); i++) {
-                                auto key = std::to_string(i);
+                            for (const auto& [line, ptr] : ProgressLineMap) {
+                                auto key = std::to_string(line);
                                 if (jdata.count(key)) {
-                                    *ProgressLineMap.at(i) = jdata[key];
+                                    *ptr = jdata[key];
                                 } else {
-                                    *ProgressLineMap.at(i) = "";
+                                    *ptr = "";
                                 }
                             }
                             if (jdata.count("9")) {
@@ -430,16 +427,6 @@ void App::calculateProgress() {
 
                             }
             
-                            // Beregn OCR-progresjonen til progressbar
-                            if (!ocrLine.empty()) {
-                                try {
-                                    ProgressBarOCR->progress = std::stod(ocrLine);
-                                } catch (...) {
-                                    ProgressBarOCR->progress = 0.0;
-                                }
-                                std::cout << "OCR Progress: " << ProgressBarOCR->progress << std::endl;
-                            }
-
                             // Beregn task-identifikasjonsprogresjon til progressbar
                             if (!identifyLine.empty()) {
                                 try {
@@ -451,7 +438,7 @@ void App::calculateProgress() {
                             }
 
                             // Beregn AI-behandling-progresjon til progressbar
-                            if (ProgressBarOCR->progress >= 1.0 && !taskLine.empty()) {
+                            if (!taskLine.empty()) {
                                 try {
                                     ProgressBarLLM->progress = std::stod(taskLine);
                                 } catch (...) {

--- a/app/App.h
+++ b/app/App.h
@@ -52,7 +52,6 @@ public:
     TDT4102::TextInput *ignoredTopics;
 
     ProgressBar *ProgressBarIdentify = nullptr;
-    ProgressBar *ProgressBarOCR = nullptr;
     ProgressBar *ProgressBarLLM = nullptr;
 
     TDT4102::Image *ntnuLogo = nullptr;

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -58,7 +58,7 @@ def write_progress(progress: List[int], n_steps: int, updates: Optional[Dict[int
 
         total = len(progress) * n_steps
         fraction = sum(progress) / total if total else 0.0
-        updates.setdefault(3, f"{fraction:.2f}")
+        updates.setdefault(4, f"{fraction:.2f}")
 
         update_progress_lines({idx + 1: text for idx, text in updates.items()})
     except Exception as e:


### PR DESCRIPTION
## Summary
- remove OCR progress bar and move the LLM bar up
- update progress map handling in the GUI
- compute progress on line 4 so LLM progress updates

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `meson setup builddir`
- `meson compile -C builddir`

------
https://chatgpt.com/codex/tasks/task_e_685e60a7e56c83268f08846da072d3f7