### PR TITLE
Add task range logging

### DIFF
--- a/scripts/task_boundaries.py
+++ b/scripts/task_boundaries.py
@@ -227,6 +227,12 @@ async def _assign_tasks(
         assigned.append(task_num)
         for ci in range(start, end):
             task_map[ci] = task_num
+        text = build_container_string(containers[start:end])
+        word_estimate = int(len(text) / 5)
+        log(
+            f"Task {task_num}, start marker: {start}, "
+            f"end marker: {end}, words: {word_estimate}"
+        )
     return task_map, ranges, assigned
 
 


### PR DESCRIPTION
## Summary
- add logging when assigning task ranges so we can inspect container batches

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68628d43aa20832681f3ce4c916488f6