### PR TITLE
Simplify edge task verification

### DIFF
--- a/scripts/extract_images.py
+++ b/scripts/extract_images.py
@@ -12,8 +12,6 @@ from project_config import IMG_DIR
 from utils import log
 from time import perf_counter
 import task_boundaries
-import tkinter as tk
-from tkinter import messagebox
 
 
 TEXT_CONTENT_RATIO = 40
@@ -89,11 +87,6 @@ def _make_saver(output_folder: str, subject: str, version: str, counts: Dict[str
 async def _process_image(img: np.ndarray, task_num: str, save_func, attempt: int = 0):
     text = await _get_text(img)
     ratio = len(text) / (text.count("\n") + 1)
-
-    root = tk.Tk()
-    root.withdraw()
-    messagebox.showwarning("Image Ratio", f"Image ratio for task {task_num}: {ratio:.2f}")
-    root.destroy()
 
     if ratio <= TEXT_CONTENT_RATIO:
         save_func(img, task_num)

--- a/scripts/task_boundaries.py
+++ b/scripts/task_boundaries.py
@@ -20,11 +20,6 @@ from utils import log
 
 CHECKED_TASKS = 5
 
-TASK_PATTERN = re.compile(
-    r"(Oppg(?:ave|\xE5ve)?|Task|Problem)\s*(\d+[a-zA-Z]?)",
-    re.IGNORECASE,
-)
-
 
 
 
@@ -149,6 +144,7 @@ async def confirm_task_text(
 
     for idx in range(max_checks):
         start, end = ranges[idx]
+        log(f"Checking containers {start}-{end - 1} from start")
         text = build_container_string(containers[start:end])
         prompt = _build_prompt(text)
         ans = await prompt_to_text.async_prompt_to_text(
@@ -156,8 +152,10 @@ async def confirm_task_text(
         )
         done += 1
         if str(ans).strip() == "0":
+            log(f"Containers {start}-{end - 1} invalid")
             remove.extend(range(start, end))
         else:
+            log(f"Containers {start}-{end - 1} valid")
             break
         if progress_callback:
             progress_callback(done, total_expected)
@@ -167,6 +165,7 @@ async def confirm_task_text(
         if idx < max_checks:
             break
         start, end = ranges[idx]
+        log(f"Checking containers {start}-{end - 1} from end")
         text = build_container_string(containers[start:end])
         prompt = _build_prompt(text)
         ans = await prompt_to_text.async_prompt_to_text(
@@ -174,8 +173,10 @@ async def confirm_task_text(
         )
         done += 1
         if str(ans).strip() == "0":
+            log(f"Containers {start}-{end - 1} invalid")
             remove.extend(range(start, end))
         else:
+            log(f"Containers {start}-{end - 1} valid")
             break
         if progress_callback:
             progress_callback(done, total_expected)
@@ -250,17 +251,13 @@ async def _assign_tasks(
         if expected_tasks and idx - 1 < len(expected_tasks):
             task_num = expected_tasks[idx - 1]
         else:
-            first_text = containers[start].get("text", "") if start < len(containers) else ""
-            m2 = TASK_PATTERN.search(first_text)
-            task_num = m2.group(2) if m2 else str(idx)
+            task_num = str(idx)
         assigned.append(task_num)
         for ci in range(start, end):
             task_map[ci] = task_num
-        text = build_container_string(containers[start:end])
-        word_estimate = int(len(text) / 5)
         log(
             f"Task {task_num}, start marker: {start}, "
-            f"end marker: {end}, words: {word_estimate}"
+            f"end marker: {end}"
         )
     return task_map, ranges, assigned
 

--- a/scripts/task_boundaries.py
+++ b/scripts/task_boundaries.py
@@ -18,11 +18,6 @@ import prompt_to_text
 from project_config import PROMPT_CONFIG
 from utils import log
 
-TASK_PATTERN = re.compile(
-    r"(Oppg(?:ave|\xE5ve)?|Task|Problem)\s*(\d+[a-zA-Z]?)",
-    re.IGNORECASE,
-)
-
 CHECKED_TASKS = 5
 
 
@@ -256,9 +251,7 @@ async def _assign_tasks(
         if expected_tasks and idx - 1 < len(expected_tasks):
             task_num = expected_tasks[idx - 1]
         else:
-            first_text = containers[start].get("text", "") if start < len(containers) else ""
-            m2 = TASK_PATTERN.search(first_text)
-            task_num = m2.group(2) if m2 else str(idx)
+            task_num = str(idx)
         assigned.append(task_num)
         for ci in range(start, end):
             task_map[ci] = task_num

--- a/scripts/task_boundaries.py
+++ b/scripts/task_boundaries.py
@@ -18,6 +18,11 @@ import prompt_to_text
 from project_config import PROMPT_CONFIG
 from utils import log
 
+TASK_PATTERN = re.compile(
+    r"(Oppg(?:ave|\xE5ve)?|Task|Problem)\s*(\d+[a-zA-Z]?)",
+    re.IGNORECASE,
+)
+
 CHECKED_TASKS = 5
 
 
@@ -251,7 +256,9 @@ async def _assign_tasks(
         if expected_tasks and idx - 1 < len(expected_tasks):
             task_num = expected_tasks[idx - 1]
         else:
-            task_num = str(idx)
+            first_text = containers[start].get("text", "") if start < len(containers) else ""
+            m2 = TASK_PATTERN.search(first_text)
+            task_num = m2.group(2) if m2 else str(idx)
         assigned.append(task_num)
         for ci in range(start, end):
             task_map[ci] = task_num

--- a/scripts/task_processing.py
+++ b/scripts/task_processing.py
@@ -278,7 +278,8 @@ async def process_task(task_number: str, exam: Exam) -> Exam:
     task_exam = deepcopy(exam)
     task_exam.task_number = task_number
     task_exam.exam_version = exam.exam_version
-    task_number = int(task_number)
+
+    task_idx = int(task_number)
 
     task_output = str(exam.ocr_tasks.get(task_number, ""))
 
@@ -293,7 +294,7 @@ async def process_task(task_number: str, exam: Exam) -> Exam:
             max_len=2000,
         )
     )
-    task_status[task_number] = 1
+    task_status[task_idx] = 1
     progress = [task_status[t] for t in range(1, total_task_count + 1)]
     write_progress(progress, LLM_STEPS)
 
@@ -310,7 +311,7 @@ async def process_task(task_number: str, exam: Exam) -> Exam:
     else:
         log(f"Task {task_number}: image directory does not exist")
         task_exam.images = []
-    task_status[task_number] = 2
+    task_status[task_idx] = 2
     progress = [task_status[t] for t in range(1, total_task_count + 1)]
     write_progress(progress, LLM_STEPS)
 
@@ -324,7 +325,7 @@ async def process_task(task_number: str, exam: Exam) -> Exam:
         task_exam.points = int(points_str) if points_str is not None else None
     except (TypeError, ValueError):
         task_exam.points = None
-    task_status[task_number] = 3
+    task_status[task_idx] = 3
     progress = [task_status[t] for t in range(1, total_task_count + 1)]
     write_progress(progress, LLM_STEPS)
     if task_exam.points is not None:
@@ -344,7 +345,7 @@ async def process_task(task_number: str, exam: Exam) -> Exam:
     )
     log(f"Task {task_number}: topic -> {task_exam.topic}")
     add_topics(task_exam.topic, exam)
-    task_status[task_number] = 4
+    task_status[task_idx] = 4
     progress = [task_status[t] for t in range(1, total_task_count + 1)]
     write_progress(progress, LLM_STEPS)
 
@@ -367,7 +368,7 @@ async def process_task(task_number: str, exam: Exam) -> Exam:
             pass
         elif instruction == "format_html_output":
             log(f"Task {task_number}: final HTML formatted")
-        task_status[task_number] = step_idx
+        task_status[task_idx] = step_idx
         progress = [task_status[t] for t in range(1, total_task_count + 1)]
         write_progress(progress, LLM_STEPS)
 
@@ -379,7 +380,7 @@ async def process_task(task_number: str, exam: Exam) -> Exam:
             max_len=2,
         )
     )
-    task_status[task_number] = 8
+    task_status[task_idx] = 8
     progress = [task_status[t] for t in range(1, total_task_count + 1)]
     write_progress(progress, LLM_STEPS)
 


### PR DESCRIPTION
## Summary
- remove `_indices_to_check`
- loop over the first and last few tasks in `confirm_task_text`
- adjust step counting in `detect_task_boundaries`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6862e9822410832683b4eb7d368599f7