### PR TITLE
Remove legacy matching code logic

### DIFF
--- a/scripts/object_to_json.py
+++ b/scripts/object_to_json.py
@@ -31,7 +31,6 @@ def main(tasks):
             exam,
             {
                 "total_tasks": task_dict.get("total_tasks", 0),
-                "matching_codes": task_dict.get("matching_codes", []),
                 "exam_topics": task_dict.get("exam_topics", []),
                 "tasks": [],
             },
@@ -39,8 +38,6 @@ def main(tasks):
 
         if task_dict.get("total_tasks") is not None:
             exam_data["total_tasks"] = task_dict["total_tasks"]
-        if task_dict.get("matching_codes"):
-            exam_data["matching_codes"] = task_dict["matching_codes"]
         if task_dict.get("exam_topics"):
             exam_data["exam_topics"] = task_dict["exam_topics"]
 
@@ -52,7 +49,6 @@ def main(tasks):
                 "subject",
                 "exam_version",
                 "total_tasks",
-                "matching_codes",
                 "exam_topics",
                 "task_numbers",
                 "ocr_tasks",

--- a/tasks.json
+++ b/tasks.json
@@ -2,9 +2,6 @@
     "IFYX1000": {
         "V24": {
             "total_tasks": 16,
-            "matching_codes": [
-                "IFYX1000"
-            ],
             "exam_topics": [
                 "Bevegelse",
                 "Mekanikk",


### PR DESCRIPTION
## Summary
- drop `matching_codes` from `Exam`
- update topic handling to only use the main subject code
- clean up object->JSON writer
- remove `matching_codes` entries from tasks.json

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686e7dd2da508326b4f05cfc934450c2