### PR TITLE
Remove deprecated fields from task pipeline

### DIFF
--- a/scripts/object_handling.py
+++ b/scripts/object_handling.py
@@ -76,7 +76,6 @@ def add_task(task: Any) -> None:
                 existing_topics.append(t)
         subj["topics"] = existing_topics
 
-    image_count = len(task_dict.get("images", []))
     task_copy = {
         k: v
         for k, v in task_dict.items()
@@ -84,12 +83,10 @@ def add_task(task: Any) -> None:
         not in {
             "subject",
             "exam_version",
-            "total_tasks",
             "exam_topics",
             "task_numbers",
             "ocr_tasks",
-            "images",
-            "code",
+            "total_tasks",
         }
     }
 
@@ -129,6 +126,5 @@ def add_task(task: Any) -> None:
         f"Exam: {exam}, "
         f"Task: {num_str}, "
         f"Subject: {subject} "
-        f"({image_count} bilder)"
     )
 


### PR DESCRIPTION
## Summary
- drop `images`, `code` and `total_tasks` fields from `Exam`
- remove image collection logic and related keys from object handling

## Testing
- `python -m py_compile $(git ls-files '*.py' -z | xargs -0)`

------
https://chatgpt.com/codex/tasks/task_e_688a0ce3c16c8326aefca6e2d51d439e