### PR TITLE
Position PowerShell window for Python script

### DIFF
--- a/app/App.cpp
+++ b/app/App.cpp
@@ -300,8 +300,22 @@ void App::startProcessing() {
         dirFile << "\"formula\":\"" << escape_json(selectedFormulaSheet->getText()) << "\"}";
 
         // Start Python-script i en bakgrunnstråd
-        std::thread([]() {
-            std::system("start powershell -Command \"python main.py; pause\"");
+        std::filesystem::path psScript = rootDir / "app" / "launch_and_move.ps1";
+        std::thread([psScript]() {
+            int pw_x = 100 + WINDOW_WIDTH;
+            int pw_y = 100 + WINDOW_HEIGHT;
+            int pw_w = 400;
+            int pw_h = 600;
+
+            int charW = pw_w / 8;
+            int charH = pw_h / 16;
+
+            std::string cmd = "start powershell -NoExit -File \"" + psScript.string() +
+                              "\" -X " + std::to_string(pw_x) +
+                              " -Y " + std::to_string(pw_y) +
+                              " -W " + std::to_string(charW) +
+                              " -H " + std::to_string(charH);
+            std::system(cmd.c_str());
         }).detach();
 
         startTimer();


### PR DESCRIPTION
## Summary
- Start the Python workflow via PowerShell with explicit window position and size to avoid overlap with the main app window.

## Testing
- `git ls-files '*.py' -z | xargs -0 python -m py_compile && echo 'py_compile success'`
- `meson setup builddir` *(fails: command not found)*
- `pip install meson` *(fails: Could not find a version that satisfies the requirement meson)*
- `meson compile -C builddir` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f69807a5c83268cbb46fd57721781