### PR TITLE
Convert topic enums to strings when updating exams

### DIFF
--- a/scripts/object_handling.py
+++ b/scripts/object_handling.py
@@ -2,6 +2,7 @@ import json
 import re
 from dataclasses import asdict
 from typing import Any, Dict, List
+from enum import Enum
 from project_config import EXAMS_JSON
 from utils import *
 
@@ -41,7 +42,7 @@ def add_exam(subject: str, exam_version: str) -> None:
     _save_json(data)
 
 
-def add_topics(subject: str, exam_version: str, topics: List[str]) -> None:
+def add_topics(subject: str, exam_version: str, topics: List[Any]) -> None:
     """Add topics to a subject if they are not already present."""
     if not topics:
         return
@@ -50,10 +51,11 @@ def add_topics(subject: str, exam_version: str, topics: List[str]) -> None:
     exam_version = exam_version.strip()
     subj = data.setdefault(subject, {"topics": [], "exams": {}})
     subj["exams"].setdefault(exam_version, {"tasks": []})
-    existing = subj.get("topics", [])
+    existing = [t.name if isinstance(t, Enum) else t for t in subj.get("topics", [])]
     for topic in topics:
-        if topic not in existing:
-            existing.append(topic)
+        topic_name = topic.name if isinstance(topic, Enum) else topic
+        if topic_name not in existing:
+            existing.append(topic_name)
     subj["topics"] = existing
     _save_json(data)
 
@@ -71,10 +73,11 @@ def add_task(task: Any) -> None:
     exam_data = subj["exams"].setdefault(exam, {"tasks": []})
 
     if task_dict.get("exam_topics"):
-        existing_topics = subj.get("topics", [])
+        existing_topics = [t.name if isinstance(t, Enum) else t for t in subj.get("topics", [])]
         for t in task_dict["exam_topics"]:
-            if t not in existing_topics:
-                existing_topics.append(t)
+            topic_name = t.name if isinstance(t, Enum) else t
+            if topic_name not in existing_topics:
+                existing_topics.append(topic_name)
         subj["topics"] = existing_topics
 
     task_copy = {

--- a/scripts/task_processing.py
+++ b/scripts/task_processing.py
@@ -65,7 +65,7 @@ class Exam:
     task_text: Optional[str] = None
     # Images are handled automatically in the HTML layer
     # Code snippets are embedded directly in the task text
-    exam_topics: Enum = field(default_factory=lambda: Enum('Temaer', []))
+    exam_topics: Enum = field(default_factory=lambda: Enum('Topics', []))
     task_numbers: List[str] = field(default_factory=list)
     ocr_tasks: Dict[str, str] = field(default_factory=dict)
     ignored_topics: List[str] = field(default_factory=list)
@@ -78,7 +78,7 @@ def get_topics_from_json(emnekode: str) -> Enum:
 
     entry = data.get(emnekode.upper().strip(), {})
     topics = [t for t in entry.get("topics", []) if t is not None]
-    return Enum('Temaer', topics)
+    return Enum('Topics', topics)
 
 
 def enum_to_str(enum: Enum) -> str:


### PR DESCRIPTION
## Summary
- Handle topic enums by converting them to strings before saving in exams.json
- Normalize existing and new topics for JSON serialization
- Rename the topic enum to "Topics" for consistency across modules

## Testing
- `python - <<'PY'
import subprocess, py_compile
files = subprocess.check_output(['git','ls-files','*.py']).decode().splitlines()
for file in files:
    py_compile.compile(file)
print('py_compile success')
PY`


------
https://chatgpt.com/codex/tasks/task_e_688fad2861208326afbf0fbce13d7a70