### PR TITLE
Handle ignored topics alongside new topics

### DIFF
--- a/scripts/object_handling.py
+++ b/scripts/object_handling.py
@@ -1,7 +1,7 @@
 import json
 import re
 from dataclasses import asdict
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 from enum import Enum
 from project_config import EXAMS_JSON
 from utils import *
@@ -42,14 +42,20 @@ def add_exam(subject: str, exam_version: str) -> None:
     _save_json(data)
 
 
-def add_topics(subject: str, exam_version: str, topics: List[Any]) -> None:
-    """Add topics to a subject if they are not already present."""
-    if not topics:
+def add_topics(
+    subject: str,
+    exam_version: str,
+    topics: List[Any],
+    ignored_topics: Optional[List[str]] = None,
+) -> None:
+    """Add topics to a subject and optionally store ignored topics."""
+    if not topics and not ignored_topics:
         return
     data = _load_json()
     subject = subject.strip().upper()
     exam_version = exam_version.strip()
     subj = data.setdefault(subject, {"topics": [], "exams": {}})
+    subj.setdefault("ignored_topics", [])
     subj["exams"].setdefault(exam_version, {"tasks": []})
     existing = [t.name if isinstance(t, Enum) else t for t in subj.get("topics", [])]
     for topic in topics:
@@ -57,6 +63,11 @@ def add_topics(subject: str, exam_version: str, topics: List[Any]) -> None:
         if topic_name not in existing:
             existing.append(topic_name)
     subj["topics"] = existing
+    if ignored_topics:
+        existing_ignored = subj.setdefault("ignored_topics", [])
+        for topic in ignored_topics:
+            if topic not in existing_ignored:
+                existing_ignored.append(topic)
     _save_json(data)
 
 

--- a/scripts/task_processing.py
+++ b/scripts/task_processing.py
@@ -172,12 +172,15 @@ async def get_exam_info() -> Exam:
             )
         ).strip().upper()
 
+    new_ignored_topics: List[str] = []
     try:
         with IGNORED_FILE.open("r", encoding="utf-8") as f:
             ignored_raw = json.load(f).get("ignored", "")
         new_ignored_topics = [t.strip() for t in ignored_raw.split(",") if t.strip()]
     except Exception as e:
         log(f"Could not read ignored topics: {e}")
+
+    exam.ignored_topics = new_ignored_topics
 
 
     log(f"Subject code: {exam.subject}")
@@ -231,9 +234,13 @@ async def get_exam_info() -> Exam:
     if new_topics is not None and len(new_topics) > 3:
         print(f"New topics identified: {new_topics}")
         new_topics = [t.strip() for t in str(new_topics).split(',')]
-        object_handling.add_topics(exam.subject, exam.exam_version, new_topics)
     else:
         print("No new topics identified.")
+        new_topics = []
+
+    object_handling.add_topics(
+        exam.subject, exam.exam_version, new_topics, new_ignored_topics
+    )
 
     exam.exam_topics = get_topics_from_json(exam.subject)
     log(f"Total in subject is now: {len(list(exam.exam_topics))}")


### PR DESCRIPTION
## Summary
- Persist ignored topics by storing them in the exam state and passing them to topic handling【F:scripts/task_processing.py†L175-L183】【F:scripts/task_processing.py†L234-L243】
- Extend `add_topics` to accept an optional list of ignored topics and merge them into subject data【F:scripts/object_handling.py†L45-L71】

## Testing
- `git ls-files -z '*.py' | xargs -0 python -m py_compile`【31ebf3†L1-L2】

------
https://chatgpt.com/codex/tasks/task_e_689080e3baac8326837df301f7c29c9b